### PR TITLE
Fix stdio shutdown race for piped input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and the project follows semantic versioning.
 
+## [2.1.1] - 2026-03-26
+
+### Fixed
+
+- drain in-flight stdio responses before shutting the proxy down when client stdin closes
+- keep piped and here-string CLI usage aligned with the documented reviewer demo path
+
 ## [2.1.0] - 2026-03-26
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-transport-firewall",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-transport-firewall",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.1",
         "dotenv": "^17.3.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-transport-firewall",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Fail-closed stdio firewall for Model Context Protocol tool traffic",
   "main": "dist/cli.js",
   "bin": {

--- a/src/stdio/proxy.ts
+++ b/src/stdio/proxy.ts
@@ -117,6 +117,7 @@ export class StdioFirewallProxy {
   private clientInterface: readline.Interface | null = null;
   private targetInterface: readline.Interface | null = null;
   private targetProcess: ChildProcessWithoutNullStreams | null = null;
+  private clientInputClosed = false;
   private stopped = false;
 
   constructor(options: StdioFirewallOptions) {
@@ -158,7 +159,15 @@ export class StdioFirewallProxy {
     });
 
     this.clientInterface.on('close', () => {
-      void this.stop();
+      this.clientInputClosed = true;
+
+      if (this.targetProcess?.stdin.writable) {
+        this.targetProcess.stdin.end();
+      }
+
+      if (this.pendingRequests.size === 0) {
+        void this.stop();
+      }
     });
   }
 
@@ -212,6 +221,10 @@ export class StdioFirewallProxy {
       }
       this.pendingRequests.clear();
       this.targetProcess = null;
+
+      if (this.clientInputClosed) {
+        void this.stop();
+      }
     });
   }
 
@@ -327,6 +340,11 @@ export class StdioFirewallProxy {
         id: message.id,
         result: sanitizedResult,
       });
+
+      if (this.clientInputClosed && this.pendingRequests.size === 0) {
+        void this.stop();
+      }
+
       return;
     }
 
@@ -336,6 +354,10 @@ export class StdioFirewallProxy {
       id: message.id,
       error: sanitizedError as JsonRpcResponse['error'],
     });
+
+    if (this.clientInputClosed && this.pendingRequests.size === 0) {
+      void this.stop();
+    }
   }
 
   private writeRpc(message: JsonRpcResponse): void {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -152,4 +152,47 @@ describe('stdio firewall proxy', () => {
 
     expect((response.error as { data?: { code?: string } }).data?.code).toBe('AUTH_FAILURE');
   });
+
+  it('drains an in-flight response before stopping when client stdin closes', async () => {
+    await proxy.stop();
+
+    proxy = new StdioFirewallProxy({
+      input: clientInput,
+      output: clientOutput,
+      errorOutput: clientError,
+      targetCommand: process.execPath,
+      targetArgs: [path.join(process.cwd(), 'tests', 'fixtures', 'slow-stdio-target.js')],
+      cacheDir,
+      cacheTtlSeconds: 60,
+      alwaysCacheTools: ['search_files'],
+      neverCacheTools: [],
+      proxyAuthToken: proxyToken,
+    });
+
+    await proxy.start();
+
+    const request = {
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'search_files',
+        arguments: {
+          query: 'slow-close',
+        },
+        _meta: {
+          authorization: createNhiAuthorization(['tools.search_files']),
+        },
+      },
+    };
+
+    clientInput.end(JSON.stringify(request) + '\n');
+    const response = await waitForJsonLine(clientOutput);
+
+    expect(response.result).toEqual({
+      callCount: 1,
+      tool: 'search_files',
+      arguments: { query: 'slow-close' },
+    });
+  });
 });

--- a/tests/fixtures/slow-stdio-target.js
+++ b/tests/fixtures/slow-stdio-target.js
@@ -1,0 +1,35 @@
+import readline from 'node:readline';
+
+let callCount = 0;
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  crlfDelay: Infinity,
+});
+
+rl.on('line', (line) => {
+  const message = JSON.parse(line);
+
+  if (message.method !== 'tools/call') {
+    process.stdout.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: message.id ?? null,
+      result: { ok: true },
+    }) + '\n');
+    return;
+  }
+
+  callCount += 1;
+
+  setTimeout(() => {
+    process.stdout.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: message.id ?? null,
+      result: {
+        callCount,
+        tool: message.params?.name ?? null,
+        arguments: message.params?.arguments ?? null,
+      },
+    }) + '\n');
+  }, 100);
+});

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -316,7 +316,7 @@ export default function Dashboard() {
         </Card>
 
         <footer className="text-center text-gray-600 text-sm pt-4 border-t border-gray-800">
-          <p>MCP Transport Firewall v2.1.0</p>
+          <p>MCP Transport Firewall v2.1.1</p>
           <p className="text-xs mt-1">Fail-closed stdio firewall with an HTTP review harness</p>
         </footer>
       </div>


### PR DESCRIPTION
## Summary
- keep the stdio proxy alive until in-flight responses are flushed after client stdin closes
- add a regression test and slow target fixture for the shutdown race
- roll the patch release version to 2.1.1

## Verification
- npm run verify:all
