### PR TITLE
Make repository docs and templates user-first

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,5 +1,5 @@
 name: Bug report
-description: Report a reproducible defect in the stdio firewall, HTTP harness, admin plane, or dashboard.
+description: Report a reproducible defect in the stdio firewall, HTTP companion service, admin plane, or dashboard.
 title: "[bug] "
 labels:
   - bug
@@ -10,7 +10,7 @@ body:
       label: Affected surface
       options:
         - stdio firewall
-        - HTTP review harness
+        - HTTP companion service
         - admin API
         - dashboard
         - CI / release packaging

--- a/.github/ISSUE_TEMPLATE/detection-gap.yml
+++ b/.github/ISSUE_TEMPLATE/detection-gap.yml
@@ -3,8 +3,7 @@ description: Report a missed unsafe flow or an over-blocking trust-gate decision
 title: "[detection] "
 labels:
   - detection-gap
-  - detection-gap
-  - detection-gap
+  - security
 body:
   - type: dropdown
     id: class

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Propose a concrete improvement to the firewall, docs, demos, or reviewer experience.
+description: Propose a concrete improvement to the firewall, docs, demos, or developer experience.
 title: "[feature] "
 labels:
   - enhancement
@@ -22,6 +22,6 @@ body:
     id: evidence
     attributes:
       label: Why this matters
-      description: Reviewer, maintainer, or user impact.
+      description: User, operator, maintainer, or developer impact.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/security-report.yml
+++ b/.github/ISSUE_TEMPLATE/security-report.yml
@@ -17,7 +17,7 @@ body:
       label: Affected surface
       options:
         - stdio firewall
-        - HTTP review harness
+        - HTTP companion service
         - admin API
         - dashboard
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,12 +1,12 @@
 ## Summary
 
-- describe the user-visible or reviewer-visible change
+- describe the user-visible or maintainer-visible change
 - list the main files or subsystems touched
 
 ## Why
 
 - explain the problem being solved
-- explain how the change stays aligned with the fail-closed stdio-first product shape
+- explain how the change fits the fail-closed stdio-first product shape
 
 ## Verification
 
@@ -14,6 +14,6 @@
 - [ ] `npm run demo:stdio` if runtime or trust-gate behavior changed
 - [ ] docs updated if claims, demos, release notes, or repo metadata changed
 
-## Reviewer Notes
+## Follow-Up Notes
 
 - note any residual risks, unsupported claims, or follow-up work

--- a/.github/release.yml
+++ b/.github/release.yml
@@ -12,7 +12,7 @@ changelog:
         - area:runtime
         - area:stdio
         - area:http
-    - title: Reviewer Packaging
+    - title: Documentation And Repo Packaging
       labels:
         - area:docs
         - area:github

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,11 @@
 # AGENTS.md
 
-This repository is optimized for coding agents and external reviewers evaluating a fail-closed MCP security control.
+This repository includes guidance for coding agents and maintainers working on a fail-closed MCP security control.
 
 ## Primary Product Boundary
 
 - Treat `src/cli.ts` and `src/stdio/proxy.ts` as the primary runtime.
-- Treat `src/index.ts` as a secondary HTTP review harness, not the primary product story.
+- Treat `src/index.ts` as a secondary HTTP companion service, not the primary product story.
 - Do not describe the project as a generic MCP gateway. The core claim is fail-closed transport inspection at the stdio boundary.
 
 ## Required Verification
@@ -16,7 +16,7 @@ Before declaring work complete, run:
 npm run verify:all
 ```
 
-If you change runtime behavior, trust gates, or demos, also confirm the reviewer demo still works:
+If you change runtime behavior, trust gates, or demos, also confirm the stdio demo still works:
 
 ```bash
 npm run demo:stdio

--- a/README.md
+++ b/README.md
@@ -2,22 +2,16 @@
 
 Fail-closed stdio firewall for Model Context Protocol tool traffic.
 
-This repository packages two runnable surfaces:
+Use it when you want a local control point between an MCP client and local tools, with default-deny behavior for auth, scope, trust-boundary, schema, and egress violations.
+
+This repository ships two runnable surfaces:
 
 - a primary stdio firewall that sits between an agent client and a local MCP tool server
-- an HTTP review harness that reuses the same trust gates for downstream HTTP tool routes
+- an HTTP companion service that reuses the same trust gates for downstream HTTP tool routes
 
-The stdio runtime is the product boundary that matters most. The HTTP `/mcp` server exists for compatibility testing, route registration, cache inspection, and dashboard review.
+The stdio runtime is the main product path. The HTTP `/mcp` service exists for compatibility testing, route registration, cache inspection, and dashboard use.
 
-## What To Read
-
-- evaluator walkthroughs: [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md)
-- evidence benchmark: [docs/EVIDENCE_BENCHMARK.md](docs/EVIDENCE_BENCHMARK.md)
-- threat model: [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md)
-- reviewer guide: [docs/REVIEWER_GUIDE.md](docs/REVIEWER_GUIDE.md)
-- example payloads: [examples/README.md](examples/README.md)
-
-## Security Properties
+## What It Does
 
 - fail-closed authorization with a shared-secret NHI-style envelope
 - per-tool scope checks before tool execution
@@ -27,23 +21,6 @@ The stdio runtime is the product boundary that matters most. The HTTP `/mcp` ser
 - structured egress inspection for ShadowLeak-style exfiltration, sensitive path access, and shell-injection markers
 - response sanitization plus L1/L2 caching for allowlisted read-style tools
 - admin API and React dashboard for route, cache, rate-limit, circuit-breaker, preflight, and SIEM inspection
-
-## Repository Map
-
-```text
-src/cli.ts                stdio entrypoint
-src/stdio/proxy.ts        stdio firewall runtime
-src/index.ts              HTTP review harness
-src/admin/                admin API and built UI hosting
-src/middleware/           trust gates and fail-closed validators
-src/cache/                L1 memory cache and L2 file cache
-src/proxy/                HTTP routing, circuit breaker, response sanitizing
-ui/                       React dashboard
-scripts/                  reproducible reviewer demos
-examples/                 demo target and payload samples
-docs/                     threat model and evaluator guidance
-tests/                    Jest suites for gates, HTTP, admin, and stdio paths
-```
 
 ## Quick Start
 
@@ -60,19 +37,19 @@ npm --prefix ui install
 Copy-Item .env.example .env
 ```
 
-3. Run the full verification set.
-
-```bash
-npm run verify:all
-```
-
-4. Run the reproducible stdio demo.
+3. Run the stdio demo.
 
 ```bash
 npm run demo:stdio
 ```
 
-5. Run the repeatable benchmark and capture the reviewer packet.
+4. Optional: run the full verification set.
+
+```bash
+npm run verify:all
+```
+
+5. Optional: run the repeatable benchmark.
 
 ```bash
 npm run benchmark:stdio
@@ -94,18 +71,22 @@ Expected benchmark outcomes:
 - zero cache consistency failures across repeated allow cases
 - blocked cases report the expected denial codes
 
-## Primary Runtime
+## Run Modes
 
-For the stdio firewall, see [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md).
+For the stdio firewall:
 
-For the HTTP review harness, run:
+```bash
+npm run start:cli -- -- node examples/demo-target.js
+```
+
+For the HTTP companion service:
 
 ```bash
 npm run dev
 npm --prefix ui run dev
 ```
 
-The HTTP path is secondary and exists for compatibility testing, route registration, cache inspection, and dashboard review.
+The HTTP path is secondary and exists for compatibility testing, route registration, cache inspection, and dashboard use.
 
 ## Docker
 
@@ -113,13 +94,38 @@ The HTTP path is secondary and exists for compatibility testing, route registrat
 docker compose up --build
 ```
 
-The Docker packaging brings up the HTTP review harness and the admin dashboard in one container:
+Docker brings up the HTTP companion service and the admin dashboard in one container:
 
 - [http://localhost:3000/health](http://localhost:3000/health)
 - [http://localhost:9090/health](http://localhost:9090/health)
 - [http://localhost:9090](http://localhost:9090)
 
-Use `npm run demo:stdio` for transport-boundary validation. The Docker deployment is primarily a packaged review surface for the dashboard and HTTP compatibility harness.
+Use `npm run demo:stdio` when you want to validate the transport boundary directly. The Docker path is mostly for the dashboard and HTTP companion service.
+
+## Documentation
+
+- threat model: [docs/THREAT_MODEL.md](docs/THREAT_MODEL.md)
+- stdio walkthrough: [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md)
+- benchmark methodology: [docs/EVIDENCE_BENCHMARK.md](docs/EVIDENCE_BENCHMARK.md)
+- audit and review notes: [docs/REVIEWER_GUIDE.md](docs/REVIEWER_GUIDE.md)
+- examples and payloads: [examples/README.md](examples/README.md)
+
+## Repository Map
+
+```text
+src/cli.ts                stdio entrypoint
+src/stdio/proxy.ts        stdio firewall runtime
+src/index.ts              HTTP companion service
+src/admin/                admin API and built UI hosting
+src/middleware/           trust gates and fail-closed validators
+src/cache/                L1 memory cache and L2 file cache
+src/proxy/                HTTP routing, circuit breaker, response sanitizing
+ui/                       React dashboard
+scripts/                  demos and repeatable benchmarks
+examples/                 demo target and payload samples
+docs/                     threat model, benchmark, and operator notes
+tests/                    Jest suites for gates, HTTP, admin, and stdio paths
+```
 
 ## Trust Gates
 
@@ -142,7 +148,7 @@ Use `npm run demo:stdio` for transport-boundary validation. The Docker deploymen
 | `MCP_ADMIN_ENABLED` | stdio + HTTP | enable admin API and dashboard | `false` |
 | `MCP_ADMIN_PORT` | stdio + HTTP | admin port | `9090` |
 | `ADMIN_TOKEN` | admin | bearer token for protected admin endpoints | none |
-| `MCP_PORT` | HTTP | HTTP review harness port | `3000` |
+| `MCP_PORT` | HTTP | HTTP companion service port | `3000` |
 | `MCP_SERVER_ID` | HTTP | cache namespace key prefix | `default` |
 | `MCP_ADMIN_CORS_ORIGIN` | admin | allowed admin origin | `*` |
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -10,7 +10,7 @@ This repository implements a fail-closed MCP transport firewall. Security report
 - replay or preflight bypass
 - data exfiltration bypass
 - response sanitization bypass
-- failures that allow unsafe traffic to reach the stdio target or HTTP harness
+- failures that allow unsafe traffic to reach the stdio target or HTTP companion service
 
 ## Supported Versions
 

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -12,7 +12,7 @@
 - operating system
 - Node.js version
 - exact command used
-- whether you used the stdio runtime, HTTP harness, or Docker path
+- whether you used the stdio runtime, HTTP companion service, or Docker path
 - expected behavior
 - actual behavior
 - logs or screenshots with sensitive data removed

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,14 +3,14 @@
 ## Stdio Demo
 
 - `demo-target.js`: local JSON-RPC tool server used by the stdio firewall demo and tests
-- `evidence-corpus.json`: reviewer benchmark corpus for false-positive and blocked-case measurement
+- `evidence-corpus.json`: benchmark corpus for regression and false-positive measurement
 
 The delayed target used to reproduce the shutdown-race regression lives in `tests/fixtures/slow-stdio-target.js`, not in this directory.
 
-For the complete Windows and Linux evaluator path, see [docs/EVALUATOR_WALKTHROUGH.md](docs/EVALUATOR_WALKTHROUGH.md).
-For the repeatable evidence packet, see [docs/EVIDENCE_BENCHMARK.md](../docs/EVIDENCE_BENCHMARK.md) and run `npm run benchmark:stdio`.
+For the complete Windows and Linux walkthrough, see [docs/EVALUATOR_WALKTHROUGH.md](../docs/EVALUATOR_WALKTHROUGH.md).
+For the repeatable benchmark output, see [docs/EVIDENCE_BENCHMARK.md](../docs/EVIDENCE_BENCHMARK.md) and run `npm run benchmark:stdio`.
 
-Canonical reviewer path:
+Quick demo path:
 
 ```bash
 npm run build
@@ -25,7 +25,7 @@ npm run start:cli -- -- node examples/demo-target.js
 
 Then write JSON-RPC lines to stdin. If `PROXY_AUTH_TOKEN` is configured, include `_meta.authorization` inside the request body.
 
-## HTTP Review Harness
+## HTTP Companion Service
 
 - `register-route.json`: admin payload for registering a downstream HTTP tool route
 - `tool-call.json`: MCP `tools/call` payload for the HTTP `/mcp` harness

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mcp-transport-firewall",
   "version": "2.1.1",
-  "description": "Fail-closed stdio firewall for Model Context Protocol tool traffic",
+  "description": "CLI firewall for fail-closed MCP stdio traffic",
   "main": "dist/cli.js",
   "bin": {
     "mcp-transport-firewall": "dist/cli.js"


### PR DESCRIPTION
## Summary
- rewrite the main README around user and operator onboarding instead of audit-first language
- rename GitHub templates and support/security wording away from reviewer-centric phrasing
- clean up release and issue template metadata that looked auto-generated or grant-driven

## Verification
- npm run demo:stdio

## Notes
- no runtime behavior changed
- no release created