### PR TITLE
fix(release): tighten parity guards and retry window

### DIFF
--- a/scripts/verify-registry-metadata.mjs
+++ b/scripts/verify-registry-metadata.mjs
@@ -94,8 +94,8 @@ export const verifyRegistryMetadata = ({ pkg, env = process.env, registryMetadat
 
 export const main = async () => {
   const pkg = readPackageJson();
-  const attempts = Number(readArgValue('--attempts') ?? process.env.REGISTRY_VERIFY_ATTEMPTS ?? 10);
-  const delayMs = Number(readArgValue('--delay-ms') ?? process.env.REGISTRY_VERIFY_DELAY_MS ?? 6000);
+  const attempts = Number(readArgValue('--attempts') ?? process.env.REGISTRY_VERIFY_ATTEMPTS ?? 20);
+  const delayMs = Number(readArgValue('--delay-ms') ?? process.env.REGISTRY_VERIFY_DELAY_MS ?? 10000);
   let result = null;
 
   for (let attempt = 1; attempt <= attempts; attempt += 1) {

--- a/scripts/verify-release-parity.mjs
+++ b/scripts/verify-release-parity.mjs
@@ -36,7 +36,7 @@ const normalizeRepositoryUrl = (originUrl) => {
 
   try {
     const parsedUrl = new URL(normalizedUrl);
-    if (!/github\.com$/i.test(parsedUrl.hostname)) {
+    if (parsedUrl.hostname.toLowerCase() !== 'github.com') {
       return null;
     }
 

--- a/tests/release-guardrails.test.ts
+++ b/tests/release-guardrails.test.ts
@@ -203,6 +203,30 @@ describe('release guardrails', () => {
     );
   });
 
+  it('rejects lookalike hostnames even when the owner and repo path match', () => {
+    const result = verifyReleaseParity({
+      pkg: {
+        version: '2.2.4',
+      },
+      env: {
+        GITHUB_REF_NAME: 'v2.2.4',
+        GITHUB_REPOSITORY: 'shleder/mcp-transport-firewall',
+      },
+      readGitFn: (...args: string[]) => {
+        if (args[0] === 'config') {
+          return 'https://notgithub.com/shleder/mcp-transport-firewall.git';
+        }
+
+        return 'abc123';
+      },
+    });
+
+    expect(result.normalizedOriginRepository).toBeNull();
+    expect(result.mismatches).toContain(
+      'remote.origin.url must point to shleder/mcp-transport-firewall, got https://notgithub.com/shleder/mcp-transport-firewall.git'
+    );
+  });
+
   it('reports a missing origin remote as a structured mismatch', () => {
     const result = verifyReleaseParity({
       pkg: {


### PR DESCRIPTION
## Summary
- require an exact `github.com` hostname when normalizing origin remotes for release parity checks
- add regression coverage for lookalike hosts such as `notgithub.com`
- extend the default npm registry verification window so fresh publishes have more time to propagate before the release workflow fails

## Why
PR #44 tightened release parity, but one remaining review item was still valid after merge: the hostname check accepted lookalike domains that merely ended with `github.com`. The `v2.2.4` tag also showed that the post-publish registry verification window was too short for real npm propagation, which skipped automatic GitHub release creation even though the package eventually published successfully.

## Additional context
- this is a direct follow-up to `#44`
- `v2.2.4` has already been published to npm and manually completed on GitHub
- this PR makes the next semver cut less brittle

## Verification
- `npm run verify:all`