### PR TITLE
ci(actions): update workflows for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
 env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   quality:
@@ -19,9 +20,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -63,7 +64,7 @@ jobs:
           NODE
 
       - name: Upload stdio benchmark evidence packet
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stdio-evidence-benchmark
           path: evidence.json
@@ -79,10 +80,10 @@ jobs:
       packages: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Log in to GitHub Container Registry
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -90,7 +91,7 @@ jobs:
 
       - name: Extract metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -99,10 +100,10 @@ jobs:
             type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build and Push
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           push: true

--- a/.github/workflows/release-npm.yml
+++ b/.github/workflows/release-npm.yml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*.*.*'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   release:
     name: Verify, Benchmark, And Publish
@@ -15,11 +18,11 @@ jobs:
       id-token: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -72,7 +75,7 @@ jobs:
           NODE
 
       - name: Upload stdio benchmark evidence packet
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: stdio-evidence-benchmark
           path: evidence.json
@@ -88,15 +91,23 @@ jobs:
           EXPECTED_GIT_HEAD: ${{ github.sha }}
 
       - name: Publish GitHub release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: evidence.json
-          body: |
-            Release evidence:
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cat > release-notes.txt <<'EOF'
+          Release evidence:
 
-            - full verification suite passed
-            - stdio benchmark attached as `evidence.json`
-            - npm tarball smoke checks passed before publication
+          - full verification suite passed
+          - stdio benchmark attached as `evidence.json`
+          - npm tarball smoke checks passed before publication
+          EOF
+
+          if gh release view "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+            gh release upload "${GITHUB_REF_NAME}" evidence.json --repo "${GITHUB_REPOSITORY}" --clobber
+            gh release edit "${GITHUB_REF_NAME}" --repo "${GITHUB_REPOSITORY}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.txt
+          else
+            gh release create "${GITHUB_REF_NAME}" evidence.json --repo "${GITHUB_REPOSITORY}" --title "${GITHUB_REF_NAME}" --notes-file release-notes.txt
+          fi
 
       - name: Summarize published release identity
         run: |


### PR DESCRIPTION
## Summary
- move the official GitHub and Docker actions in CI/release workflows to current Node24-ready major tags
- replace the Node20-only release publishing action with an idempotent gh CLI release step
- opt workflows into Node24 action runtime now with FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true

## Validation
- npm test -- --runTestsByPath tests/release-guardrails.test.ts
- manually verified updated action refs in .github/workflows/ci.yml and .github/workflows/release-npm.yml
- confirmed official upstream releases/action metadata before changing tags

## Notes
- softprops/action-gh-release v2.6.1 still declares runs.using: node20, so it was removed instead of patch-bumped