### PR TITLE
docs(public): tighten human-facing security copy

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Guided setup request
+  - name: Setup request
     url: https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml
-    about: Ask for help protecting a real Codex or Claude Code MCP workflow.
+    about: Ask for help protecting a real local MCP workflow.
   - name: Security reporting policy
     url: https://github.com/shleder/mcp-transport-firewall/blob/main/SECURITY.md
     about: Follow the security policy for sensitive findings instead of posting exploit details publicly.
-  - name: Guided setup and audits
+  - name: Setup notes
     url: https://github.com/shleder/mcp-transport-firewall/blob/main/docs/GUIDED_SETUP_AND_AUDITS.md
-    about: Use the guided setup path if you want help hardening a real Codex or Claude Code local MCP workflow.
+    about: Use the setup path if you want help hardening a real local MCP workflow.
   - name: Workflow hardening guide
     url: https://github.com/shleder/mcp-transport-firewall/blob/main/docs/WORKFLOW_HARDENING.md
-    about: Start with the operator guide for risky local MCP calls, auth gaps, and fail-closed rollout.
+    about: Start with the workflow guide for risky local MCP calls, auth gaps, and fail-closed rollout.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -22,6 +22,6 @@ body:
     id: evidence
     attributes:
       label: Why this matters
-      description: User, operator, maintainer, or developer impact.
+      description: User, team, maintainer, or developer impact.
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/guided-setup-request.yml
+++ b/.github/ISSUE_TEMPLATE/guided-setup-request.yml
@@ -1,13 +1,13 @@
-name: Guided setup request
-description: Request guided help for a protected local MCP workflow, hardening review, or trust-gate tuning.
-title: "[guided-setup] "
+name: Setup request
+description: Request help for a protected local MCP workflow, setup review, or policy tuning.
+title: "[setup] "
 body:
   - type: input
     id: client
     attributes:
       label: MCP client
-      description: Codex, Claude Code, or another MCP-enabled client.
-      placeholder: Codex
+      description: Which MCP client or integration are you using?
+      placeholder: Desktop MCP client
     validations:
       required: true
   - type: input
@@ -29,7 +29,7 @@ body:
     id: help_needed
     attributes:
       label: Help needed
-      description: Setup walkthrough, hardening audit, trust-gate tuning, or something else concrete.
+      description: Setup walkthrough, workflow review, policy tuning, or something else concrete.
     validations:
       required: true
   - type: textarea
@@ -52,8 +52,8 @@ body:
   - type: dropdown
     id: feedback
     attributes:
-      label: Willing to share feedback
-      description: Early operator requests are strongest when they can produce usage notes, a quote, or a case study.
+      label: Can you share follow-up results
+      description: Only if you are comfortable sharing a short note about what worked or what failed.
       options:
         - yes
         - maybe

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,20 +13,20 @@ The format is based on Keep a Changelog and the project follows semantic version
 
 ## 2.2.4 - 2026-03-31
 
-- adds a guided setup intake path for Codex and Claude Code operators who want help protecting a local MCP workflow
+- adds a setup request path for people who want help protecting a local MCP workflow
 - adds a workflow hardening guide focused on risky local MCP calls, auth gaps, exfiltration patterns, and fail-closed rollout
-- makes the service-led path visible in `README.md` and `SUPPORT.md` so early operator help requests have one clear route
-- updates the public roadmap around first users, release trust, and operator feedback loops
+- makes the setup-help path visible in `README.md` and `SUPPORT.md` so workflow questions have one clear route
+- updates the public roadmap around first users, release trust, and workflow feedback loops
 
 ## 2.2.3 - 2026-03-31
 
-- restores canonical package identity checks for `repository`, `homepage`, and `bugs`
+- restores exact package identity checks for `repository`, `homepage`, and `bugs`
 - adds release guardrails for GitHub tag, GitHub release, and npm registry parity
 - narrows public onboarding around one primary use case: risky local MCP file/search tool calls
 - makes the short `npm run demo:stdio` path the primary proof before broader integration paths
-- sharpens package metadata around risky local MCP tool calls and Codex/Claude Code operator fit
-- adds a public guided setup and workflow hardening request path for early operator intake
-- routes service-led help through the issue chooser instead of mixing it with bugs or security reports
+- sharpens package metadata around risky local MCP tool calls and local workflow use
+- adds a public setup request and workflow review path for real installation questions
+- routes setup help through the issue chooser instead of mixing it with bugs or security reports
 
 
 - 2.2.2 removes noisy cache-hit stderr output from the runtime path
@@ -49,7 +49,7 @@ The format is based on Keep a Changelog and the project follows semantic version
 
 - expanded the strict schema registry across common read, write, list, search, execute, and fetch tool contracts
 - aligned HTTP and stdio paths around the same primary tool-invocation helper and alias-aware cache defaults
-- documented the benchmark methodology and supported schema families for operators and maintainers
+- documented the benchmark methodology and supported schema families for users and maintainers
 - switched the persistent L2 cache to SQLite-backed storage and updated Windows test teardown to close the cache explicitly
 - limited npm package contents to the runtime entrypoints and user-facing docs required for one-line installs
 - updated CI to publish the stdio benchmark artifact, workflow summary, and tarball smoke evidence for reproducible inspection

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 ## Best For
 
-- individual Codex and Claude Code users who already run local MCP servers
+- people who already run a local MCP client with a downstream MCP server
 - local MCP-enabled coding workflows that should not run high-risk calls blindly
 - file, read, list, and search-oriented downstream MCP servers
 - teams that want a fail-closed transport control before downstream execution
@@ -72,19 +72,19 @@ Protected downstream proxy mode is the primary integration path.
 
 Use `PROXY_AUTH_TOKEN` for fail-closed auth, and `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON` as the default downstream target input. See [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md) for client examples.
 
-## Need Help Hardening A Local MCP Workflow?
+## Setup Help
 
-Use the guided setup path when you want practical help instead of a generic feature request.
+Use the setup request path when you need help wiring or reviewing a real local MCP workflow.
 
-- guided setup for a Codex or Claude Code local MCP stack
-- workflow hardening audit for risky file, search, fetch, or execute paths
-- trust-gate tuning for a specific downstream MCP server
+- setup help for one local MCP stack
+- workflow review for risky file, search, fetch, or execute paths
+- policy tuning for a specific downstream MCP server
 
 Start here:
 
-- read the operator guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- open a guided setup request: [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
-- use the scoped intake and early-operator offer details: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
+- read the workflow guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
+- open a setup request: [setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- review the setup notes: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
 
 ## What This Is Not
 
@@ -170,7 +170,7 @@ The recommended order is:
 - evidence bundle: [docs/EVIDENCE_BUNDLE.md](docs/EVIDENCE_BUNDLE.md)
 - ship checklist: [docs/SHIP_CHECKLIST.md](docs/SHIP_CHECKLIST.md)
 - workflow hardening guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- guided setup and audits: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
+- setup notes: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
 
 Reference docs:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,13 @@
 # Roadmap
 
-This project is already usable as a fail-closed MCP transport firewall. The next steps are about keeping the stdio path solid, making release flow boring, and turning early operator use into real trust, feedback, and repeatable setup paths without bloating the core.
+This project is already usable as a fail-closed MCP transport firewall. The next steps are about keeping the stdio path solid, making the release flow boring, and turning real usage into better defaults and clearer setup paths without bloating the core.
 
 Near term:
 
-- keep one sharp story for the primary user: local Codex or Claude Code operators protecting risky MCP calls
+- keep one sharp story for the primary user: local MCP client workflows protecting risky MCP calls
 - ship a coherent release line where the git tag, GitHub release, and npm latest all match
-- collect first guided setup requests and tight operator feedback from real local workflows
-- add more operator notes for Windows and Linux client setups
+- collect first setup requests and direct feedback from real local workflows
+- add more notes for Windows and Linux client setups
 - keep benchmark snapshots and evidence docs aligned with the current package
 
 Mid term:
@@ -16,10 +16,10 @@ Mid term:
 - improve dashboard visibility for gate decisions, blocked-request trends, and metrics scrape status
 - add more denial-code regression cases for indirect prompt-injection traffic
 - keep release checklists and provenance notes versioned with the release line
-- turn repeated guided setup pain into clearer product defaults and stronger docs
+- turn repeated setup pain into clearer product defaults and stronger docs
 
 Later:
 
 - keep benchmark snapshots comparable across releases
 - add optional integrations for external metrics collectors and log pipelines without changing the fail-closed core
-- document more deployment patterns for local tool servers and operator environments
+- document more deployment patterns for local tool servers and MCP client environments

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,4 +25,4 @@ Include:
 Please avoid live credentials, private datasets, or third-party secrets in reports.
 Fixes are expected on `main` and, when practical, on the latest supported tagged line.
 
-If you need guided setup or workflow hardening help rather than reporting a vulnerability, use [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md) instead of `SECURITY.md`.
+If you need setup help or a workflow review rather than reporting a vulnerability, use [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md) instead of `SECURITY.md`.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,8 +4,8 @@ Use the GitHub issue chooser for the fastest path:
 
 - usage questions: open the closest issue template
 - bug reports: open a tight reproduction with exact inputs
-- feature proposals: describe the operator problem and the expected outcome
-- guided setup or workflow hardening help: start with [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md) and then open the [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- feature proposals: describe the user problem and the expected outcome
+- setup help or workflow review: start with [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md) and then open the [setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
 - security-sensitive findings: use `SECURITY.md` instead of posting exploit detail in an issue
 
 Useful context for any report or setup request:
@@ -21,6 +21,6 @@ Useful context for any report or setup request:
 Direct request paths:
 
 - issue chooser: [github.com/shleder/mcp-transport-firewall/issues/new/choose](https://github.com/shleder/mcp-transport-firewall/issues/new/choose)
-- guided setup request: [guided-setup-request.yml](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- setup request: [guided-setup-request.yml](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
 
 The fastest path to triage is still a narrow repro with exact inputs and observed output.

--- a/docs/CLIENT_CONFIG_EXAMPLES.md
+++ b/docs/CLIENT_CONFIG_EXAMPLES.md
@@ -2,7 +2,7 @@
 
 Use this page when wiring `mcp-transport-firewall` into a local MCP setup.
 The default path is the protected downstream proxy.
-The primary fit is an individual Codex or Claude Code user protecting a risky local MCP workflow.
+The primary fit is a local MCP client protecting a risky local MCP workflow.
 
 Supported entry points:
 
@@ -108,4 +108,4 @@ npx --yes mcp-transport-firewall
 npx --yes mcp-transport-firewall -- node C:/absolute/path/to/your-mcp-server.js
 ```
 
-If you want help adapting one of these examples to a real local MCP stack, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).
+If you want help adapting one of these examples to a real local MCP stack, use [Setup notes](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/DISTRIBUTION_NOTES.md
+++ b/docs/DISTRIBUTION_NOTES.md
@@ -8,7 +8,7 @@ Current package surface:
 - the full validation environment can be reproduced with `docker compose up --build`
 - tests, demo paths, and benchmark corpus live in this repository
 - the npm tarball is smoke-tested before publication
-- guided setup and audit requests are routed through the public GitHub issue chooser and `docs/GUIDED_SETUP_AND_AUDITS.md`
+- setup requests are routed through the public GitHub issue chooser and `docs/GUIDED_SETUP_AND_AUDITS.md`
 
 The runtime stays intentionally narrow:
 
@@ -36,4 +36,4 @@ Useful follow-up docs:
 - client config examples: `docs/CLIENT_CONFIG_EXAMPLES.md`
 - runtime contract: `docs/RUNTIME_CONTRACT.md`
 - verification guide: `docs/VERIFICATION_GUIDE.md`
-- guided setup and audits: `docs/GUIDED_SETUP_AND_AUDITS.md`
+- setup notes: `docs/GUIDED_SETUP_AND_AUDITS.md`

--- a/docs/GUIDED_SETUP_AND_AUDITS.md
+++ b/docs/GUIDED_SETUP_AND_AUDITS.md
@@ -1,31 +1,25 @@
-# Guided Setup And Audits
+# Setup Notes And Workflow Review
 
 Use this page when the package proof is clear but you want help adapting it to a real local MCP workflow.
 
 Best fit:
 
-- individual Codex or Claude Code users already running local MCP servers
+- people already running a local MCP client with a downstream MCP server
 - small teams with shared local MCP tooling and a narrow protected workflow
-- operators who need a fail-closed layer before risky file, search, fetch, or execute-shaped tool calls
+- people who need a fail-closed layer before risky file, search, fetch, or execute-shaped tool calls
 
 What this repository can help with:
 
-- guided setup for one local MCP stack
-- workflow hardening audit for a real downstream MCP server
-- trust-gate tuning for a specific read, search, fetch, or high-trust action path
-
-Early operator offer:
-
-- first 10 guided setup requests can start with a free 20-minute risk review
-- reduced-cost or free setup work is possible when the workflow is a strong fit for a reusable example, quote, or case study
-- this is for proof and operator feedback first, not for broad custom consulting intake
+- setup help for one local MCP stack
+- workflow review for a real downstream MCP server
+- policy tuning for a specific read, search, fetch, or high-trust action path
 
 How to request help:
 
-1. Read the operator guide: [WORKFLOW_HARDENING.md](WORKFLOW_HARDENING.md)
-2. Open the guided setup request directly: [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+1. Read the workflow guide: [WORKFLOW_HARDENING.md](WORKFLOW_HARDENING.md)
+2. Open the setup request directly: [setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
 3. Include sanitized details about:
-   - your MCP client (`Codex`, `Claude Code`, or similar)
+   - your MCP client
    - the downstream MCP server you want to protect
    - the risky workflow you want to gate
    - the expected outcome
@@ -36,8 +30,8 @@ What to include in a useful request:
 - operating system
 - Node.js version
 - exact command or config shape you want to protect
-- current failure mode, risk, or operator concern
-- whether you want a proof path, a setup walkthrough, or a hardening review
+- current failure mode, risk, or workflow concern
+- whether you want a proof path, a setup walkthrough, or a workflow review
 
 What this is not:
 

--- a/docs/PROXY_SETUP.md
+++ b/docs/PROXY_SETUP.md
@@ -1,7 +1,7 @@
 ## Proxy Setup
 
 Use this page when you want the firewall in front of a local read/search-shaped downstream MCP server.
-The primary fit is an individual Codex or Claude Code operator protecting a risky local MCP workflow.
+The primary fit is a local MCP client protecting a risky local MCP workflow.
 
 Primary proof path:
 
@@ -82,4 +82,4 @@ Recommended client configuration:
 
 If you need a self-contained MCP server without a downstream target, standalone bundled mode is still available through `npx -y mcp-transport-firewall`.
 
-If you want help getting from the demo path to a real protected workflow, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).
+If you want help getting from the demo path to a real protected workflow, use [Setup notes](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/RUNTIME_CONTRACT.md
+++ b/docs/RUNTIME_CONTRACT.md
@@ -1,6 +1,6 @@
 ## Runtime Contract
 
-This page describes the expected runtime behavior of `mcp-transport-firewall` for local operators and downstream MCP setups.
+This page describes the expected runtime behavior of `mcp-transport-firewall` for local users and downstream MCP setups.
 
 Supported entry points:
 

--- a/docs/STDIO_BENCHMARK_GUIDE.md
+++ b/docs/STDIO_BENCHMARK_GUIDE.md
@@ -1,6 +1,6 @@
 ## Stdio Benchmark Guide
 
-This repository includes a repeatable stdio benchmark for operators and maintainers.
+This repository includes a repeatable stdio benchmark for users and maintainers.
 It measures `false positives`, `false negatives`, and cache behavior at the transport boundary.
 
 The benchmark covers:

--- a/docs/WORKFLOW_HARDENING.md
+++ b/docs/WORKFLOW_HARDENING.md
@@ -1,12 +1,12 @@
 ## Workflow Hardening Guide
 
-Use this page when the package itself is clear but the real operator question is practical:
+Use this page when the package itself is clear but the real workflow question is practical:
 
-- how do I put this in front of a live Codex or Claude Code MCP workflow?
+- how do I put this in front of a live local MCP workflow?
 - what risky local MCP calls should I guard first?
 - how do I roll this out without opening a bigger hole than I close?
 
-This guide stays narrow on purpose. The best current fit is a local MCP operator who already has a downstream tool server and wants a fail-closed control before risky local execution.
+This guide stays narrow on purpose. The best current fit is someone who already has a downstream tool server and wants a fail-closed control before risky local execution.
 
 ## Start With One Protected Workflow
 
@@ -22,9 +22,9 @@ Recommended order:
 
 If you cannot explain which single workflow you want to protect first, stop and narrow scope before adding more trust gates or more tool surface.
 
-## The Operator Pain This Is Built For
+## Common Reasons People Use This
 
-The early user is not looking for generic security language. The early user usually has one of these problems:
+Most real setups start with one of these problems:
 
 - a local MCP server can read or search more than it should, and the client will call it too easily
 - a risky fetch, path, or shell-shaped payload can reach a downstream target before anyone notices
@@ -55,12 +55,12 @@ Why this matters:
 
 ### 3. Shared Local Tooling For A Small Team
 
-Best when several operators reuse one local MCP setup and want the same trust defaults.
+Best when several people reuse one local MCP setup and want the same trust defaults.
 
 Why this comes second:
 
 - team rollout is more valuable after a single-user path is already proven
-- it is easier to tune trust gates when one operator workflow is already stable
+- it is easier to tune trust gates when one workflow is already stable
 
 ## What To Check Before You Trust The Rollout
 
@@ -72,9 +72,9 @@ Why this comes second:
 
 If any of those are missing, treat the rollout as incomplete.
 
-## When To Ask For Guided Setup
+## When To Ask For Help
 
-Use the guided setup path when:
+Use the setup request path when:
 
 - you can run the demo locally but the real client wiring still feels brittle
 - you are not sure which trust gate is blocking a real workflow
@@ -83,8 +83,4 @@ Use the guided setup path when:
 
 Open a request here:
 
-- [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
-
-Early operator note:
-
-- the first 10 guided setup requests can ask for a short workflow review in exchange for tight feedback, a short quote, or a reproducible user story
+- [setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)

--- a/package.json
+++ b/package.json
@@ -32,9 +32,8 @@
   "keywords": [
     "mcp",
     "model-context-protocol",
-    "codex",
-    "claude-code",
     "local-mcp",
+    "mcp-client",
     "security",
     "firewall",
     "stdio",


### PR DESCRIPTION
Tighten the public repo copy so it reads like a small security tool maintained by a human engineer instead of a client-branded or AI-shaped project.

This keeps the existing setup-help path, support links, and stable public filenames, but rewrites the visible wording around them to be drier, more client-agnostic, and easier to trust. It also removes client-brand keywords from package metadata and cleans the remaining public GitHub template labels.

No runtime, CLI, packaging, or workflow behavior changes are included here. The checks for this batch were `npm run pack:dry-run` and `npm run pack:smoke`.