### PR TITLE
docs(support): tighten workflow intake surface

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,14 +1,14 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Guided setup request
+  - name: Workflow intake
     url: https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml
-    about: Ask for help protecting a real Codex or Claude Code MCP workflow.
+    about: Open a narrow public intake for one protected local MCP workflow.
   - name: Security reporting policy
     url: https://github.com/shleder/mcp-transport-firewall/blob/main/SECURITY.md
     about: Follow the security policy for sensitive findings instead of posting exploit details publicly.
-  - name: Guided setup and audits
+  - name: Workflow intake notes
     url: https://github.com/shleder/mcp-transport-firewall/blob/main/docs/GUIDED_SETUP_AND_AUDITS.md
-    about: Use the guided setup path if you want help hardening a real Codex or Claude Code local MCP workflow.
+    about: Read the intake boundaries and when private follow-up is appropriate.
   - name: Workflow hardening guide
     url: https://github.com/shleder/mcp-transport-firewall/blob/main/docs/WORKFLOW_HARDENING.md
-    about: Start with the operator guide for risky local MCP calls, auth gaps, and fail-closed rollout.
+    about: Start with the rollout guide for risky local MCP calls, auth gaps, and fail-closed rollout.

--- a/.github/ISSUE_TEMPLATE/guided-setup-request.yml
+++ b/.github/ISSUE_TEMPLATE/guided-setup-request.yml
@@ -29,7 +29,7 @@ body:
     id: help_needed
     attributes:
       label: Intake goal
-      description: Setup walkthrough, hardening review, trust-gate diagnosis, or another concrete need.
+      description: Blocked integration, trust-gate diagnosis, rollout question, or another concrete need.
     validations:
       required: true
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/guided-setup-request.yml
+++ b/.github/ISSUE_TEMPLATE/guided-setup-request.yml
@@ -1,12 +1,12 @@
-name: Guided setup request
-description: Request guided help for a protected local MCP workflow, hardening review, or trust-gate tuning.
-title: "[guided-setup] "
+name: Workflow intake
+description: Request help for one protected local MCP workflow, a hardening review, or trust-gate diagnosis.
+title: "[workflow-intake] "
 body:
   - type: input
     id: client
     attributes:
-      label: MCP client
-      description: Codex, Claude Code, or another MCP-enabled client.
+      label: MCP client or host tool
+      description: Codex, Claude Code, or another tool that is driving the MCP workflow.
       placeholder: Codex
     validations:
       required: true
@@ -28,35 +28,24 @@ body:
   - type: textarea
     id: help_needed
     attributes:
-      label: Help needed
-      description: Setup walkthrough, hardening audit, trust-gate tuning, or something else concrete.
+      label: Intake goal
+      description: Setup walkthrough, hardening review, trust-gate diagnosis, or another concrete need.
     validations:
       required: true
   - type: textarea
     id: sanitized_context
     attributes:
-      label: Sanitized context
+      label: Sanitized evidence
       description: Share only sanitized commands, configs, logs, or screenshots. Do not include secrets.
     validations:
       required: true
   - type: dropdown
     id: follow_up
     attributes:
-      label: Private follow-up needed
+      label: Private follow-up required
       description: Choose yes if the real details cannot be shared publicly after sanitization.
       options:
         - no
         - yes
-    validations:
-      required: true
-  - type: dropdown
-    id: feedback
-    attributes:
-      label: Willing to share feedback
-      description: Early operator requests are strongest when they can produce usage notes, a quote, or a case study.
-      options:
-        - yes
-        - maybe
-        - no
     validations:
       required: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,10 +13,10 @@ The format is based on Keep a Changelog and the project follows semantic version
 
 ## 2.2.4 - 2026-03-31
 
-- adds a guided setup intake path for Codex and Claude Code operators who want help protecting a local MCP workflow
+- adds a workflow intake path for Codex and Claude Code users who want help protecting a local MCP workflow
 - adds a workflow hardening guide focused on risky local MCP calls, auth gaps, exfiltration patterns, and fail-closed rollout
-- makes the service-led path visible in `README.md` and `SUPPORT.md` so early operator help requests have one clear route
-- updates the public roadmap around first users, release trust, and operator feedback loops
+- makes the support intake path visible in `README.md` and `SUPPORT.md` so early workflow issues have one clear route
+- updates the public roadmap around first users, release trust, and workflow feedback loops
 
 ## 2.2.3 - 2026-03-31
 
@@ -24,9 +24,9 @@ The format is based on Keep a Changelog and the project follows semantic version
 - adds release guardrails for GitHub tag, GitHub release, and npm registry parity
 - narrows public onboarding around one primary use case: risky local MCP file/search tool calls
 - makes the short `npm run demo:stdio` path the primary proof before broader integration paths
-- sharpens package metadata around risky local MCP tool calls and Codex/Claude Code operator fit
-- adds a public guided setup and workflow hardening request path for early operator intake
-- routes service-led help through the issue chooser instead of mixing it with bugs or security reports
+- sharpens package metadata around risky local MCP tool calls and Codex/Claude Code workflow fit
+- adds a public workflow intake and trust-gate help path for early support intake
+- routes workflow help through the issue chooser instead of mixing it with bugs or security reports
 
 
 - 2.2.2 removes noisy cache-hit stderr output from the runtime path

--- a/README.md
+++ b/README.md
@@ -72,19 +72,15 @@ Protected downstream proxy mode is the primary integration path.
 
 Use `PROXY_AUTH_TOKEN` for fail-closed auth, and `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON` as the default downstream target input. See [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md) for client examples.
 
-## Need Help Hardening A Local MCP Workflow?
+## Support Intake
 
-Use the guided setup path when you want practical help instead of a generic feature request.
-
-- guided setup for a Codex or Claude Code local MCP stack
-- workflow hardening audit for risky file, search, fetch, or execute paths
-- trust-gate tuning for a specific downstream MCP server
+Use the support path only when the protected workflow is already clear and you need help wiring, narrowing, or debugging it.
 
 Start here:
 
-- read the operator guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- open a guided setup request: [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
-- use the scoped intake and early-operator offer details: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
+- read the workflow guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
+- open a sanitized workflow intake issue: [workflow intake](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- use the scoped intake notes when the public issue needs more context: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
 
 ## What This Is Not
 
@@ -170,7 +166,7 @@ The recommended order is:
 - evidence bundle: [docs/EVIDENCE_BUNDLE.md](docs/EVIDENCE_BUNDLE.md)
 - ship checklist: [docs/SHIP_CHECKLIST.md](docs/SHIP_CHECKLIST.md)
 - workflow hardening guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- guided setup and audits: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
+- workflow intake notes: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
 
 Reference docs:
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,13 +1,13 @@
 # Roadmap
 
-This project is already usable as a fail-closed MCP transport firewall. The next steps are about keeping the stdio path solid, making release flow boring, and turning early operator use into real trust, feedback, and repeatable setup paths without bloating the core.
+This project is already usable as a fail-closed MCP transport firewall. The next steps are about keeping the stdio path solid, making release flow boring, and turning early use into real trust, product feedback, and repeatable default paths without bloating the core.
 
 Near term:
 
-- keep one sharp story for the primary user: local Codex or Claude Code operators protecting risky MCP calls
+- keep one sharp story for the primary user: local Codex or Claude Code users protecting risky MCP calls
 - ship a coherent release line where the git tag, GitHub release, and npm latest all match
-- collect first guided setup requests and tight operator feedback from real local workflows
-- add more operator notes for Windows and Linux client setups
+- collect first workflow intake issues and tight product feedback from real local workflows
+- add more setup notes for Windows and Linux client setups
 - keep benchmark snapshots and evidence docs aligned with the current package
 
 Mid term:
@@ -16,10 +16,10 @@ Mid term:
 - improve dashboard visibility for gate decisions, blocked-request trends, and metrics scrape status
 - add more denial-code regression cases for indirect prompt-injection traffic
 - keep release checklists and provenance notes versioned with the release line
-- turn repeated guided setup pain into clearer product defaults and stronger docs
+- turn repeated workflow-intake pain into clearer product defaults and stronger docs
 
 Later:
 
 - keep benchmark snapshots comparable across releases
 - add optional integrations for external metrics collectors and log pipelines without changing the fail-closed core
-- document more deployment patterns for local tool servers and operator environments
+- document more deployment patterns for local tool servers and real local environments

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -25,4 +25,4 @@ Include:
 Please avoid live credentials, private datasets, or third-party secrets in reports.
 Fixes are expected on `main` and, when practical, on the latest supported tagged line.
 
-If you need guided setup or workflow hardening help rather than reporting a vulnerability, use [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md) instead of `SECURITY.md`.
+If you need workflow intake or trust-gate help rather than reporting a vulnerability, use [workflow intake notes](docs/GUIDED_SETUP_AND_AUDITS.md) instead of `SECURITY.md`.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -4,8 +4,8 @@ Use the GitHub issue chooser for the fastest path:
 
 - usage questions: open the closest issue template
 - bug reports: open a tight reproduction with exact inputs
-- feature proposals: describe the operator problem and the expected outcome
-- guided setup or workflow hardening help: start with [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md) and then open the [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- feature proposals: describe the problem and the expected outcome
+- protected workflow intake: start with [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md) and then open the [workflow intake issue](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
 - security-sensitive findings: use `SECURITY.md` instead of posting exploit detail in an issue
 
 Useful context for any report or setup request:
@@ -18,9 +18,15 @@ Useful context for any report or setup request:
 - actual behavior
 - sanitized logs, screenshots, or config fragments
 
+Workflow intake policy:
+
+- keep the public issue sanitized and narrow
+- use private follow-up only when the real config, logs, or environment detail cannot be shared safely
+- do not post secrets, private repository URLs, customer data, or exploit detail in public issues
+
 Direct request paths:
 
 - issue chooser: [github.com/shleder/mcp-transport-firewall/issues/new/choose](https://github.com/shleder/mcp-transport-firewall/issues/new/choose)
-- guided setup request: [guided-setup-request.yml](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- workflow intake issue: [guided-setup-request.yml](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
 
 The fastest path to triage is still a narrow repro with exact inputs and observed output.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -27,6 +27,6 @@ Workflow intake policy:
 Direct request paths:
 
 - issue chooser: [github.com/shleder/mcp-transport-firewall/issues/new/choose](https://github.com/shleder/mcp-transport-firewall/issues/new/choose)
-- workflow intake issue: [guided-setup-request.yml](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- workflow intake issue: [workflow intake](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
 
 The fastest path to triage is still a narrow repro with exact inputs and observed output.

--- a/docs/CLIENT_CONFIG_EXAMPLES.md
+++ b/docs/CLIENT_CONFIG_EXAMPLES.md
@@ -108,4 +108,4 @@ npx --yes mcp-transport-firewall
 npx --yes mcp-transport-firewall -- node C:/absolute/path/to/your-mcp-server.js
 ```
 
-If you want help adapting one of these examples to a real local MCP stack, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).
+If you want help adapting one of these examples to a real local MCP stack, use [workflow intake notes](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/DISTRIBUTION_NOTES.md
+++ b/docs/DISTRIBUTION_NOTES.md
@@ -8,7 +8,6 @@ Current package surface:
 - the full validation environment can be reproduced with `docker compose up --build`
 - tests, demo paths, and benchmark corpus live in this repository
 - the npm tarball is smoke-tested before publication
-- guided setup and audit requests are routed through the public GitHub issue chooser and `docs/GUIDED_SETUP_AND_AUDITS.md`
 
 The runtime stays intentionally narrow:
 
@@ -36,4 +35,4 @@ Useful follow-up docs:
 - client config examples: `docs/CLIENT_CONFIG_EXAMPLES.md`
 - runtime contract: `docs/RUNTIME_CONTRACT.md`
 - verification guide: `docs/VERIFICATION_GUIDE.md`
-- guided setup and audits: `docs/GUIDED_SETUP_AND_AUDITS.md`
+- workflow intake notes: `docs/GUIDED_SETUP_AND_AUDITS.md`

--- a/docs/GUIDED_SETUP_AND_AUDITS.md
+++ b/docs/GUIDED_SETUP_AND_AUDITS.md
@@ -1,46 +1,43 @@
-# Guided Setup And Audits
+# Workflow Intake Notes
 
-Use this page when the package proof is clear but you want help adapting it to a real local MCP workflow.
+Use this page when the package proof is clear but you need help adapting it to one real local MCP workflow.
 
 Best fit:
 
-- individual Codex or Claude Code users already running local MCP servers
-- small teams with shared local MCP tooling and a narrow protected workflow
-- operators who need a fail-closed layer before risky file, search, fetch, or execute-shaped tool calls
+- one existing local MCP workflow with a concrete integration gap or risk
+- a narrow protected workflow that already has a clear downstream server
+- cases where a sanitized public issue is enough to explain the problem, or can at least explain the boundary of it
 
 What this repository can help with:
 
-- guided setup for one local MCP stack
-- workflow hardening audit for a real downstream MCP server
-- trust-gate tuning for a specific read, search, fetch, or high-trust action path
-
-Early operator offer:
-
-- first 10 guided setup requests can start with a free 20-minute risk review
-- reduced-cost or free setup work is possible when the workflow is a strong fit for a reusable example, quote, or case study
-- this is for proof and operator feedback first, not for broad custom consulting intake
+- narrow setup help for one local MCP stack
+- workflow hardening review for one real downstream MCP server
+- trust-gate diagnosis for a specific read, search, fetch, or high-trust action path
 
 How to request help:
 
-1. Read the operator guide: [WORKFLOW_HARDENING.md](WORKFLOW_HARDENING.md)
-2. Open the guided setup request directly: [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+1. Read the workflow guide: [WORKFLOW_HARDENING.md](WORKFLOW_HARDENING.md)
+2. Open the workflow intake issue directly: [workflow intake](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
 3. Include sanitized details about:
-   - your MCP client (`Codex`, `Claude Code`, or similar)
+   - your MCP client or host tool
    - the downstream MCP server you want to protect
    - the risky workflow you want to gate
    - the expected outcome
 4. Do not post secrets, tokens, private repo URLs, or customer data
+5. If the issue cannot stay useful after sanitization, say so in the intake and move the sensitive detail to private follow-up only if needed
 
 What to include in a useful request:
 
 - operating system
 - Node.js version
 - exact command or config shape you want to protect
-- current failure mode, risk, or operator concern
+- current failure mode, risk, or engineering concern
 - whether you want a proof path, a setup walkthrough, or a hardening review
 
 What this is not:
 
 - not a vulnerability disclosure path; use `SECURITY.md` for security findings
 - not a managed control plane or hosted enterprise onboarding flow
+- not a public workflow-review program
+- not open-ended consulting intake
 - not a promise that every custom setup request will be accepted

--- a/docs/GUIDED_SETUP_AND_AUDITS.md
+++ b/docs/GUIDED_SETUP_AND_AUDITS.md
@@ -11,7 +11,7 @@ Best fit:
 What this repository can help with:
 
 - narrow setup help for one local MCP stack
-- workflow hardening review for one real downstream MCP server
+- workflow hardening diagnosis for one real downstream MCP server
 - trust-gate diagnosis for a specific read, search, fetch, or high-trust action path
 
 How to request help:
@@ -32,12 +32,11 @@ What to include in a useful request:
 - Node.js version
 - exact command or config shape you want to protect
 - current failure mode, risk, or engineering concern
-- whether you want a proof path, a setup walkthrough, or a hardening review
+- whether you want a proof path, blocked-integration diagnosis, or trust-gate diagnosis
 
 What this is not:
 
 - not a vulnerability disclosure path; use `SECURITY.md` for security findings
-- not a managed control plane or hosted enterprise onboarding flow
-- not a public workflow-review program
-- not open-ended consulting intake
+- not a hosted control plane
+- not a broad intake path for unrelated workflows
 - not a promise that every custom setup request will be accepted

--- a/docs/PROXY_SETUP.md
+++ b/docs/PROXY_SETUP.md
@@ -82,4 +82,4 @@ Recommended client configuration:
 
 If you need a self-contained MCP server without a downstream target, standalone bundled mode is still available through `npx -y mcp-transport-firewall`.
 
-If you want help getting from the demo path to a real protected workflow, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).
+If you want help getting from the demo path to a real protected workflow, use [workflow intake notes](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/WORKFLOW_HARDENING.md
+++ b/docs/WORKFLOW_HARDENING.md
@@ -1,12 +1,12 @@
 ## Workflow Hardening Guide
 
-Use this page when the package itself is clear but the real operator question is practical:
+Use this page when the package itself is clear but the real workflow question is practical:
 
-- how do I put this in front of a live Codex or Claude Code MCP workflow?
+- how do I put this in front of a live local MCP workflow?
 - what risky local MCP calls should I guard first?
 - how do I roll this out without opening a bigger hole than I close?
 
-This guide stays narrow on purpose. The best current fit is a local MCP operator who already has a downstream tool server and wants a fail-closed control before risky local execution.
+This guide stays narrow on purpose. The best current fit is a local MCP user who already has a downstream tool server and wants a fail-closed control before risky local execution.
 
 ## Start With One Protected Workflow
 
@@ -22,9 +22,9 @@ Recommended order:
 
 If you cannot explain which single workflow you want to protect first, stop and narrow scope before adding more trust gates or more tool surface.
 
-## The Operator Pain This Is Built For
+## The Workflow Problems This Is Built For
 
-The early user is not looking for generic security language. The early user usually has one of these problems:
+The early user is not looking for generic security language. The usual starting point is one of these workflow problems:
 
 - a local MCP server can read or search more than it should, and the client will call it too easily
 - a risky fetch, path, or shell-shaped payload can reach a downstream target before anyone notices
@@ -72,19 +72,15 @@ Why this comes second:
 
 If any of those are missing, treat the rollout as incomplete.
 
-## When To Ask For Guided Setup
+## When To Use Workflow Intake
 
-Use the guided setup path when:
+Use the workflow intake path when:
 
 - you can run the demo locally but the real client wiring still feels brittle
 - you are not sure which trust gate is blocking a real workflow
 - you want a workflow hardening review before putting the setup in front of a wider team
 - you need custom trust-gate tuning for a downstream server with a non-obvious tool contract
 
-Open a request here:
+Open the intake here:
 
-- [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
-
-Early operator note:
-
-- the first 10 guided setup requests can ask for a short workflow review in exchange for tight feedback, a short quote, or a reproducible user story
+- [workflow intake](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)

--- a/docs/WORKFLOW_HARDENING.md
+++ b/docs/WORKFLOW_HARDENING.md
@@ -55,12 +55,12 @@ Why this matters:
 
 ### 3. Shared Local Tooling For A Small Team
 
-Best when several operators reuse one local MCP setup and want the same trust defaults.
+Best when several users reuse one local MCP setup and want the same trust defaults.
 
 Why this comes second:
 
 - team rollout is more valuable after a single-user path is already proven
-- it is easier to tune trust gates when one operator workflow is already stable
+- it is easier to tune trust gates when one user workflow is already stable
 
 ## What To Check Before You Trust The Rollout
 
@@ -78,7 +78,7 @@ Use the workflow intake path when:
 
 - you can run the demo locally but the real client wiring still feels brittle
 - you are not sure which trust gate is blocking a real workflow
-- you want a workflow hardening review before putting the setup in front of a wider team
+- you want a workflow hardening diagnosis before putting the setup in front of a wider team
 - you need custom trust-gate tuning for a downstream server with a non-obvious tool contract
 
 Open the intake here:


### PR DESCRIPTION
## Summary
- tighten the public support path into a dry workflow-intake flow
- remove legacy service-style wording from support, workflow, and public history docs
- keep public issues sanitized and make private follow-up explicitly conditional

## Verification
- npm run pack:dry-run
- npm run pack:smoke