### PR TITLE
docs(workflow): center proof on filesystem/search path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 </p>
 
 <p align="center">
-  <strong>Fail-closed proxy for risky local MCP file/search tool calls.</strong>
+  <strong>Fail-closed proxy for local filesystem/search MCP workflows.</strong>
 </p>
 
 <p align="center">
@@ -13,16 +13,16 @@
   <a href="LICENSE"><img alt="license" src="https://img.shields.io/badge/license-MIT-0f172a?style=for-the-badge" /></a>
 </p>
 
-`mcp-transport-firewall` sits between a coding-agent client and a local downstream MCP server. It inspects `tools/call` over `stdio`, lets read/search-shaped requests continue, and blocks risky exfiltration, path, and shell-style patterns before they reach the target.
+`mcp-transport-firewall` sits between a coding-agent client and a local downstream MCP server. The primary fit is one local filesystem/search workflow: let read, list, and search requests continue, but block risky exfiltration, path, and shell-style patterns before they reach downstream execution.
 
 ## Best For
 
-- individual Codex and Claude Code users who already run local MCP servers
-- local MCP-enabled coding workflows that should not run high-risk calls blindly
+- one local filesystem/search MCP server that a coding agent already uses
+- repo investigation, config review, and read-only local search workflows
 - file, read, list, and search-oriented downstream MCP servers
-- teams that want a fail-closed transport control before downstream execution
+- teams that want to prove one safe local workflow before wider rollout
 
-## 60-Second Proof
+## 3-Minute Proof
 
 ```bash
 npm install
@@ -50,6 +50,18 @@ block: missing auth denied with code=AUTH_FAILURE
 
 See [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md) for the example transcript.
 
+## Flagship Workflow
+
+Start with one protected local filesystem/search MCP server for repo investigation.
+
+Typical shape:
+
+1. the agent uses a local MCP server for `search_files`, reads, and listing
+2. the firewall sits on the stdio path in front of that server
+3. safe search/read traffic continues, while risky fetch, path, or shell-shaped requests fail closed
+
+This is the shortest path from install to trust because the proof is visible in one run and maps cleanly to a real coding workflow.
+
 ## Install In Your MCP Client
 
 Protected downstream proxy mode is the primary integration path.
@@ -57,7 +69,7 @@ Protected downstream proxy mode is the primary integration path.
 ```json
 {
   "mcpServers": {
-    "protected-local-tooling": {
+    "protected-filesystem-search": {
       "command": "npx",
       "args": ["-y", "mcp-transport-firewall"],
       "env": {
@@ -72,19 +84,11 @@ Protected downstream proxy mode is the primary integration path.
 
 Use `PROXY_AUTH_TOKEN` for fail-closed auth, and `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON` as the default downstream target input. See [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md) for client examples.
 
-## Need Help Hardening A Local MCP Workflow?
+## Real Workflows
 
-Use the guided setup path when you want practical help instead of a generic feature request.
-
-- guided setup for a Codex or Claude Code local MCP stack
-- workflow hardening audit for risky file, search, fetch, or execute paths
-- trust-gate tuning for a specific downstream MCP server
-
-Start here:
-
-- read the operator guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- open a guided setup request: [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
-- use the scoped intake and early-operator offer details: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
+- solo repo investigation: put the firewall in front of a local filesystem/search MCP server and let the agent trace `TODO`, `auth`, `token`, `migration`, or ownership across a repo without letting a risky pivot reach downstream
+- local config and security review: let the agent search `.github/`, `Dockerfile`, `package.json`, `docs/`, and `src/`, while the transport layer blocks exfiltration-shaped or shell-style requests before execution
+- small-team rollout: prove the single-user filesystem/search path first, then reuse the same trust defaults for a shared local workflow
 
 ## What This Is Not
 
@@ -105,7 +109,7 @@ See [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md) for the explici
 
 The primary inspected surface is JSON-RPC `tools/call` over `stdio`. Blocked requests fail closed and are not forwarded to the downstream target.
 
-## Additional Modes
+## Secondary Modes
 
 ### Standalone Bundled MCP Server
 
@@ -156,27 +160,36 @@ npm install -g mcp-transport-firewall
 The recommended order is:
 
 1. prove the boundary locally with `npm run demo:stdio`
-2. integrate protected downstream proxy mode in your MCP client
-3. use standalone bundled mode only when you explicitly want embedded status tools instead of a downstream target
+2. point the proxy at one local filesystem/search MCP server
+3. verify one safe request and one blocked request in the real workflow
+4. use standalone bundled mode only when you explicitly want embedded status tools instead of a downstream target
 
 ## Docs
 
-- client setups: [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md)
 - proxy setup: [docs/PROXY_SETUP.md](docs/PROXY_SETUP.md)
+- client setups: [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md)
+- demo transcript: [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md)
+- workflow hardening guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
 - runtime contract: [docs/RUNTIME_CONTRACT.md](docs/RUNTIME_CONTRACT.md)
 - limits and non-goals: [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md)
 - risk model: [docs/RISK_MODEL.md](docs/RISK_MODEL.md)
 - verification guide: [docs/VERIFICATION_GUIDE.md](docs/VERIFICATION_GUIDE.md)
 - evidence bundle: [docs/EVIDENCE_BUNDLE.md](docs/EVIDENCE_BUNDLE.md)
 - ship checklist: [docs/SHIP_CHECKLIST.md](docs/SHIP_CHECKLIST.md)
-- workflow hardening guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
 - guided setup and audits: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
+
+## Support Intake
+
+Use the guided setup path only when the protected workflow is already clear and you need help wiring or tuning it.
+
+- read the workflow guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
+- open a sanitized intake issue: [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
+- use the scoped setup notes only when you need them: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
 
 Reference docs:
 
 - benchmark guide: [docs/STDIO_BENCHMARK_GUIDE.md](docs/STDIO_BENCHMARK_GUIDE.md)
 - benchmark snapshot: [docs/STDIO_BENCHMARK_SNAPSHOT.json](docs/STDIO_BENCHMARK_SNAPSHOT.json)
-- demo transcript: [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md)
 - architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
 - risk summary: [docs/RISK_SUMMARY.md](docs/RISK_SUMMARY.md)
 - assurance packet: [docs/ASSURANCE_PACKET.md](docs/ASSURANCE_PACKET.md)

--- a/docs/CLIENT_CONFIG_EXAMPLES.md
+++ b/docs/CLIENT_CONFIG_EXAMPLES.md
@@ -1,8 +1,8 @@
 ## Client Config Examples
 
-Use this page when wiring `mcp-transport-firewall` into a local MCP setup.
+Use this page when wiring `mcp-transport-firewall` into one local filesystem/search MCP workflow.
 The default path is the protected downstream proxy.
-The primary fit is an individual Codex or Claude Code user protecting a risky local MCP workflow.
+Start with one downstream server that mostly reads, lists, or searches local files.
 
 Supported entry points:
 
@@ -13,19 +13,19 @@ npm install -g mcp-transport-firewall
 
 Recommended order:
 
-1. protected downstream MCP server
+1. protected local filesystem/search MCP server
 2. protected local read/search demo
 3. standalone bundled MCP server
 4. direct terminal and CLI flow
 
-## Protected downstream MCP server
+## Start Here: protected local filesystem/search MCP server
 
-Use this when you already have an MCP server and want the firewall in front of it.
+Use this when you already have a local filesystem/search MCP server and want the firewall in front of it.
 
 ```json
 {
   "mcpServers": {
-    "protected-local-tooling": {
+    "protected-filesystem-search": {
       "command": "npx",
       "args": ["-y", "mcp-transport-firewall"],
       "env": {
@@ -47,9 +47,11 @@ Target input notes:
 
 If `PROXY_AUTH_TOKEN` is configured, client requests must carry `_meta.authorization` in the request body. See `scripts/stdio-demo.mjs` for a concrete Bearer envelope example.
 
+This is the flagship workflow for the package. Keep the first rollout narrow: one downstream server, one safe read/search proof, one blocked risky request.
+
 ## Protected local read/search demo
 
-Use this when you want the smallest reproducible protected workflow backed by a local read-only MCP server you control.
+Use this when you want the smallest reproducible proof before you point the proxy at a real local filesystem/search server.
 
 ```powershell
 $env:PROXY_AUTH_TOKEN = "12345678901234567890123456789012"
@@ -77,7 +79,7 @@ Example request shape:
 }
 ```
 
-This is a demo path for proof and regression testing, not a full filesystem MCP server.
+This is a demo path for proof and regression testing, not a full filesystem MCP server. Its job is to prove the transport boundary before you wire the real workflow.
 
 ## Standalone bundled MCP server
 
@@ -108,4 +110,4 @@ npx --yes mcp-transport-firewall
 npx --yes mcp-transport-firewall -- node C:/absolute/path/to/your-mcp-server.js
 ```
 
-If you want help adapting one of these examples to a real local MCP stack, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).
+If you want help adapting the primary filesystem/search path to a real local MCP stack, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/PROXY_SETUP.md
+++ b/docs/PROXY_SETUP.md
@@ -1,7 +1,7 @@
 ## Proxy Setup
 
-Use this page when you want the firewall in front of a local read/search-shaped downstream MCP server.
-The primary fit is an individual Codex or Claude Code operator protecting a risky local MCP workflow.
+Use this page when you want the firewall in front of one local filesystem/search MCP workflow.
+The primary fit is a single user proving repo investigation or config review before rolling the pattern out any wider.
 
 Primary proof path:
 
@@ -28,6 +28,15 @@ What this proves:
 - the second identical `search_files` request is served from cache
 - the `fetch_url` exfiltration sample is denied before downstream execution
 - the missing-auth sample is denied at the transport boundary
+
+## 3-To-5 Minute Rollout
+
+1. run `npm run demo:stdio` and confirm the allow, cache, and deny lines above
+2. point `MCP_TARGET_COMMAND` and `MCP_TARGET_ARGS_JSON` at one local filesystem/search MCP server
+3. ask the agent for one safe search or read action in the real workflow
+4. confirm one risky request still fails closed before downstream execution
+
+If that four-step path is not clear yet, do not widen the scope to team rollout or secondary modes.
 
 After the proof:
 
@@ -67,7 +76,7 @@ Recommended client configuration:
 ```json
 {
   "mcpServers": {
-    "protected-local-tooling": {
+    "protected-filesystem-search": {
       "command": "npx",
       "args": ["-y", "mcp-transport-firewall"],
       "env": {
@@ -79,6 +88,8 @@ Recommended client configuration:
   }
 }
 ```
+
+This is the main package story. The Docker path and standalone bundled server are still supported, but they are secondary to the protected filesystem/search workflow.
 
 If you need a self-contained MCP server without a downstream target, standalone bundled mode is still available through `npx -y mcp-transport-firewall`.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,7 @@
+# Examples
+
+Use this directory to prove the flagship workflow before wiring the package to a real local filesystem/search MCP server.
+
 - `demo-target.js`: reproducible downstream JSON-RPC target used for the README demo and regression coverage
 - `evidence-corpus.json`: benchmark corpus for regression and false-positive measurement
 
@@ -12,9 +16,11 @@ Related docs:
 
 Maintained package paths:
 
-1. primary path: protected downstream MCP server mode via `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON`
-2. demo path: protected local read/search workflow via `examples/demo-target.js`
+1. primary path: protected local filesystem/search MCP workflow via `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON`
+2. demo path: reproducible protected read/search proof via `examples/demo-target.js`
 3. secondary standalone path: bundled MCP mode via `npx -y mcp-transport-firewall`
+
+The demo target is intentionally small and reproducible. Prove the allow, cache, and deny behavior here first, then replace it with the real local filesystem/search server you want to protect.
 
 Repo-local demo path:
 
@@ -34,7 +40,7 @@ MCP client configuration path:
 ```json
 {
   "mcpServers": {
-    "protected-demo-target": {
+    "protected-filesystem-search": {
       "command": "npx",
       "args": ["-y", "mcp-transport-firewall"],
       "env": {
@@ -58,7 +64,7 @@ $env:MCP_TARGET_ARGS_JSON = "[\"C:/absolute/path/to/examples/demo-target.js\"]"
 npx --yes mcp-transport-firewall
 ```
 
-This uses a reproducible demo target for proof and regression coverage. It is not a full filesystem MCP server.
+This uses a reproducible demo target for proof and regression coverage. It is not a full filesystem MCP server, but it mirrors the search/read-shaped traffic the flagship workflow depends on.
 
 Use the GitHub fallback only when you intentionally want repository HEAD instead of the npm package:
 


### PR DESCRIPTION
## Summary
- center the top docs surface on one local filesystem/search MCP workflow
- make the proof path shorter and clearer from install to trust
- demote standalone and secondary flows behind the flagship path

## Verification
- npm run pack:dry-run
- npm run pack:smoke
- npm run demo:stdio